### PR TITLE
Add Strengths and Needs API

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -50,3 +50,4 @@ services:
       SERVER_PORT: 8080
       APP_DB_ENDPOINT: postgres:5432
       HMPPS_AUTH_BASE_URL: http://hmpps-auth:9090
+      SAN_API_BASE_URL: http://hmpps-san:3050 #TODO: Add this container

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,7 +10,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
-    SAN_API_URL: "https://api.strengths-based-needs-dev.hmpps.service.justice.gov.uk"
+    SAN_API_BASE_URL: "https://api.strengths-based-needs-dev.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,9 +10,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
-    # Template kotlin calls out to itself to provide an example of a service call
-    # TODO: This should be replaced by a call to a different service, or removed
-    EXAMPLE_API_URL: "https://template-kotlin-dev.hmpps.service.justice.gov.uk"
+    SAN_API_URL: "https://api.strengths-based-needs-dev.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,7 +10,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
-    SAN_API_URL: "https://api.strengths-based-needs-preprod.hmpps.service.justice.gov.uk"
+    SAN_API_BASE_URL: "https://api.strengths-based-needs-preprod.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,9 +10,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
-    # Template kotlin calls out to itself to provide an example of a service call
-    # TODO: This should be replaced by a call to a different service, or removed
-    EXAMPLE_API_URL: "https://template-kotlin-preprod.hmpps.service.justice.gov.uk"
+    SAN_API_URL: "https://api.strengths-based-needs-preprod.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -7,7 +7,7 @@ generic-service:
 
   env:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
-    SAN_API_URL: "https://api.strengths-based-needs.hmpps.service.justice.gov.uk"
+    SAN_API_BASE_URL: "https://api.strengths-based-needs.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -7,9 +7,7 @@ generic-service:
 
   env:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
-    # Template kotlin calls out to itself to provide an example of a service call
-    # TODO: This should be replaced by a call to a different service, or removed
-    EXAMPLE_API_URL: "https://template-kotlin.hmpps.service.justice.gov.uk"
+    SAN_API_URL: "https://api.strengths-based-needs.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/Constraints.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/Constraints.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.config
+
+class Constraints {
+  companion object {
+    const val OASYS_PK_MAX_LENGTH = 15
+    const val OASYS_PK_MIN_LENGTH = 1
+    const val REGION_PRISON_CODE_MAX_LENGTH = 15
+    const val OASYS_USER_ID_MAX_LENGTH = 15
+    const val OASYS_USER_NAME_MAX_LENGTH = 64
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/WebClientConfiguration.kt
@@ -12,10 +12,15 @@ import java.time.Duration
 @Configuration
 class WebClientConfiguration(
   @Value("\${app.services.hmpps-auth.base-url}") val hmppsAuthBaseUri: String,
+  @Value("\${app.services.strengths-and-needs-api.base-url}") val sanApiBaseUri: String,
   @Value("\${api.health-timeout:2s}") val healthTimeout: Duration,
   @Value("\${api.timeout:20s}") val timeout: Duration,
 ) {
   // HMPPS Auth health ping is required if your service calls HMPPS Auth to get a token to call other services
   @Bean
   fun hmppsAuthHealthWebClient(builder: WebClient.Builder): WebClient = builder.healthWebClient(hmppsAuthBaseUri, healthTimeout)
+
+  @Bean
+  fun sanApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient =
+    builder.authorisedWebClient(authorizedClientManager, registrationId = "san-api", url = sanApiBaseUri, timeout)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/StrengthsAndNeedsApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/StrengthsAndNeedsApi.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.request.CreateAssessmentRequest
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.response.CreateAssessmentResponse
+
+@Component
+class StrengthsAndNeedsApi(
+  val sanApiWebClient: WebClient,
+  val apiProperties: StrengthsAndNeedsApiProperties
+) {
+
+  private val logger = LoggerFactory.getLogger(StrengthsAndNeedsApi::class.java)
+
+  fun createAssessment(body: CreateAssessmentRequest): CreateAssessmentResponse? {
+    return try {
+      sanApiWebClient.post()
+        .uri(apiProperties.endpoints.create)
+        .body(BodyInserters.fromValue(body))
+        .retrieve()
+        .bodyToMono(CreateAssessmentResponse::class.java)
+        .block()
+    } catch (ex: WebClientResponseException) {
+      logger.error("HTTP error during createAssessment: Status code ${ex.statusCode}, Response body: ${ex.responseBodyAsString}", ex)
+      throw ex
+    } catch (ex: Exception) {
+      logger.error("Error during createAssessment: ${ex.message}", ex)
+      throw ex
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/StrengthsAndNeedsApiProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/StrengthsAndNeedsApiProperties.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api
+
+import jakarta.annotation.PostConstruct
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "app.services.strengths-and-needs-api")
+data class StrengthsAndNeedsApiProperties(
+  var baseUrl: String = "",
+  var endpoints: Endpoints = Endpoints(),
+  var paths: Endpoints = Endpoints()
+) {
+
+  data class Endpoints(
+    var fetch: String = "",
+    var create: String = ""
+  )
+
+  @PostConstruct
+  fun init() {
+    paths = Endpoints(
+      fetch = baseUrl + endpoints.fetch,
+      create = baseUrl + endpoints.create
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/request/CreateAssessmentRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/request/CreateAssessmentRequest.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.request
+
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDetails
+
+data class CreateAssessmentRequest (
+  val userDetails: OasysUserDetails
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/response/CreateAssessmentResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/response/CreateAssessmentResponse.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.response
+
+import java.util.*
+
+data class CreateAssessmentResponse(
+  val sanAssessmentId: UUID,
+  val sanAssessmentVersion: Long
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/entity/OasysUserDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/entity/OasysUserDetails.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.config.Constraints
+
+data class OasysUserDetails(
+  @Schema(description = "OASys User ID", example = "RB12XYZ")
+  @Size(max = Constraints.OASYS_USER_ID_MAX_LENGTH)
+  val id: String = "",
+
+  @Schema(description = "User's full name", example = "John Doe")
+  @Size(max = Constraints.OASYS_USER_NAME_MAX_LENGTH)
+  val name: String = "",
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,14 +34,27 @@ spring:
             token-uri: ${app.services.hmpps-auth.base-url}/oauth/token
 
         registration:
-          # example client registration for calling out to other services
-          # TODO: Remove / replace this registration
-          example-api:
+          san-api:
             provider: hmpps-auth
-            client-id: ${example-api.client.id}
-            client-secret: ${example-api.client.secret}
+            client-id: ${san-api.client.id}
+            client-secret: ${san-api.client.secret}
             authorization-grant-type: client_credentials
-            scope: read
+            scope: read, write
+
+app:
+  services:
+    hmpps-auth:
+      base-url: ${hmpps-auth.base-url}
+    strengths-and-needs-api:
+      base-url: ${san-api.base-url}
+      endpoints:
+        fetch: /assessment/
+        create: /assessment
+  self:
+    base-url: ${hmpps-handover.base-url}
+    endpoints:
+      oasys:
+        create: /oasys/create
 
   db:
     name: arns-coordinator


### PR DESCRIPTION
_note: This is currently written as if SAN had a simple `create` endpoint that just needed the userDetails attribute._

- Added SAN API and configuration
- Added some generic types
- Small other config changes