### PR TITLE
Add dev-only wiremock into implementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+  implementation("org.wiremock:wiremock-standalone:3.9.1")
   runtimeOnly("org.postgresql:postgresql")
 
   // DB Migration (Flyway)
@@ -19,7 +20,6 @@ dependencies {
   runtimeOnly("org.flywaydb:flyway-database-postgresql:10.18.0")
 
   testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.0.5")
-  testImplementation("org.wiremock:wiremock-standalone:3.9.1")
   testImplementation("io.swagger.parser.v3:swagger-parser:2.1.22") {
     exclude(group = "io.swagger.core.v3")
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/wiremock/WireMockInitialiser.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/wiremock/WireMockInitialiser.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@Profile("wiremock")
+class WireMockInitialiser(
+  private val wireMockProperties: WireMockProperties
+) {
+
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(WireMockInitialiser::class.java)
+  }
+
+  @Bean
+  fun wireMockServer(): WireMockServer {
+    val wireMockServer = WireMockServer(
+      WireMockConfiguration()
+        .port(wireMockProperties.port)
+        .globalTemplating(true)
+    )
+
+    wireMockServer.start()
+    log.info("WireMock server started on port ${wireMockServer.port()}")
+
+    Runtime.getRuntime().addShutdownHook(Thread { wireMockServer.stop() })
+
+    return wireMockServer
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/wiremock/WireMockProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/wiremock/WireMockProperties.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.wiremock
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Profile("wiremock")
+@Configuration
+@ConfigurationProperties(prefix = "wiremock")
+data class WireMockProperties(
+  var port: Int = 0,
+  var paths: Paths = Paths()
+) {
+  data class Paths(
+    var strengthAndNeeds: String = ""
+  )
+}

--- a/src/main/resources/application-wiremock.yaml
+++ b/src/main/resources/application-wiremock.yaml
@@ -1,0 +1,9 @@
+wiremock:
+  port: 8089
+  paths:
+    strength-and-needs: '/strength-and-needs'
+
+app:
+  services:
+    strengths-and-needs-api:
+      base-url: ${san-api.base-url:http://localhost:${wiremock.port}${wiremock.paths.strength-and-needs}}


### PR DESCRIPTION
_Note: this should absolutely be removed once the ability to turn on/off services is implemented. Without this though, all of our local container deployments will need SAN/SP APIs and their own DBs adding.

- Added a built in wiremock (activated by the wiremock profile) to stub out APIs that aren't available currently