### PR TITLE
Add create endpoint and functionality

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/features/ActionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/features/ActionService.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.features
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.CreateData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.IntegrationService
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.OperationResult
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.VersionedEntity
+
+@Service
+class ActionService(
+  private val components: List<IntegrationService>,
+) {
+
+  fun createAllEntities(createData: CreateData): OperationResult<List<VersionedEntity>> {
+    val successResponses = mutableListOf<VersionedEntity>()
+    val failureResponses = mutableListOf<String>()
+
+    components.forEach { component ->
+      when (val createResult = component.create(createData)) {
+        is OperationResult.Success -> successResponses.add(createResult.data)
+        is OperationResult.Failure -> failureResponses.add(createResult.errorMessage)
+      }
+    }
+
+    return if (failureResponses.isNotEmpty()) {
+      OperationResult.Failure(failureResponses.joinToString())
+    } else {
+      OperationResult.Success(successResponses)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/AssessmentService.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.StrengthsAndNeedsApi
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.CreateData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.IntegrationService
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.OperationResult
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.VersionedEntity
+
+@Service
+class AssessmentService(
+  private val strengthsAndNeedsApi: StrengthsAndNeedsApi,
+) : IntegrationService {
+
+  override fun create(createData: CreateData): OperationResult<VersionedEntity> {
+    return when (val result = strengthsAndNeedsApi.createAssessment(createData.assessment!!)) {
+      is StrengthsAndNeedsApi.ApiOperationResult.Failure -> {
+        OperationResult.Failure(result.errorMessage)
+      }
+      is StrengthsAndNeedsApi.ApiOperationResult.Success -> {
+        OperationResult.Success(result.data)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/StrengthsAndNeedsApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/StrengthsAndNeedsApi.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api
 
-import org.jboss.logging.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
@@ -50,7 +50,7 @@ class StrengthsAndNeedsApi(
       val cause: Throwable? = null,
     ) : ApiOperationResult<T>() {
       init {
-        Logger.getLogger(StrengthsAndNeedsApi::class.java).error(errorMessage)
+        LoggerFactory.getLogger(StrengthsAndNeedsApi::class.java).error(errorMessage)
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/StrengthsAndNeedsApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/StrengthsAndNeedsApi.kt
@@ -1,12 +1,14 @@
 package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api
 
-import org.slf4j.LoggerFactory
+import org.jboss.logging.Logger
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
-import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.request.CreateAssessmentRequest
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.request.CreateAssessmentData
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.response.CreateAssessmentResponse
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.VersionedEntity
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
 
 @Component
 class StrengthsAndNeedsApi(
@@ -14,22 +16,42 @@ class StrengthsAndNeedsApi(
   val apiProperties: StrengthsAndNeedsApiProperties,
 ) {
 
-  private val logger = LoggerFactory.getLogger(StrengthsAndNeedsApi::class.java)
-
-  fun createAssessment(body: CreateAssessmentRequest): CreateAssessmentResponse? {
+  fun createAssessment(createData: CreateAssessmentData): ApiOperationResult<VersionedEntity> {
     return try {
-      sanApiWebClient.post()
+      val result = sanApiWebClient.post()
         .uri(apiProperties.endpoints.create)
-        .body(BodyInserters.fromValue(body))
+        .body(BodyInserters.fromValue(createData))
         .retrieve()
         .bodyToMono(CreateAssessmentResponse::class.java)
+        .map {
+          VersionedEntity(
+            id = it.sanAssessmentId,
+            version = it.sanAssessmentVersion,
+            entityType = EntityType.ASSESSMENT,
+          )
+        }
         .block()
+
+      result?.let {
+        ApiOperationResult.Success(it)
+      } ?: throw IllegalStateException("Unexpected error during createAssessment")
     } catch (ex: WebClientResponseException) {
-      logger.error("HTTP error during createAssessment: Status code ${ex.statusCode}, Response body: ${ex.responseBodyAsString}", ex)
-      throw ex
+      ApiOperationResult.Failure("HTTP error during create assessment: Status code ${ex.statusCode}, Response body: ${ex.responseBodyAsString}", ex)
     } catch (ex: Exception) {
-      logger.error("Error during createAssessment: ${ex.message}", ex)
-      throw ex
+      ApiOperationResult.Failure("Unexpected error during createAssessment: ${ex.message}", ex)
+    }
+  }
+
+  sealed class ApiOperationResult<out T> {
+    data class Success<T>(val data: T) : ApiOperationResult<T>()
+
+    data class Failure<T>(
+      val errorMessage: String,
+      val cause: Throwable? = null,
+    ) : ApiOperationResult<T>() {
+      init {
+        Logger.getLogger(StrengthsAndNeedsApi::class.java).error(errorMessage)
+      }
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/request/CreateAssessmentData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/request/CreateAssessmentData.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.request
+
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.UserDetails
+
+data class CreateAssessmentData(
+  val userDetails: UserDetails,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/request/CreateAssessmentRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/request/CreateAssessmentRequest.kt
@@ -1,7 +1,0 @@
-package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.request
-
-import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDetails
-
-data class CreateAssessmentRequest(
-  val userDetails: OasysUserDetails,
-)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/response/CreateAssessmentResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/response/CreateAssessmentResponse.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.response
 
-import java.util.*
+import java.util.UUID
 
 data class CreateAssessmentResponse(
   val sanAssessmentId: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/common/entity/CreateData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/common/entity/CreateData.kt
@@ -4,6 +4,6 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.a
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api.request.CreatePlanData
 
 data class CreateData(
-  val plan: CreatePlanData,
-  val assessment: CreateAssessmentData,
+  val plan: CreatePlanData? = null,
+  val assessment: CreateAssessmentData? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/common/entity/CreateData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/common/entity/CreateData.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity
+
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.request.CreateAssessmentData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api.request.CreatePlanData
+
+data class CreateData(
+  val plan: CreatePlanData,
+  val assessment: CreateAssessmentData,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/common/entity/IntegrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/common/entity/IntegrationService.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity
+
+interface IntegrationService {
+  fun create(createData: CreateData): OperationResult<VersionedEntity>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/common/entity/UserDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/common/entity/UserDetails.kt
@@ -1,3 +1,6 @@
 package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity
 
-interface CreateResponse
+data class UserDetails(
+  val id: String,
+  val name: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/common/entity/VersionedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/common/entity/VersionedEntity.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity
+
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
+import java.util.UUID
+
+data class VersionedEntity(
+  val id: UUID,
+  val version: Long,
+  val entityType: EntityType,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/PlanService.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.CreateData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.IntegrationService
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.OperationResult
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.VersionedEntity
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api.SentencePlanApi
+
+@Service
+class PlanService(
+  private val sentencePlanApi: SentencePlanApi,
+) : IntegrationService {
+
+  override fun create(createData: CreateData): OperationResult<VersionedEntity> {
+    return when (val result = sentencePlanApi.createPlan(createData.plan!!)) {
+      is SentencePlanApi.ApiOperationResult.Failure -> {
+        OperationResult.Failure(result.errorMessage)
+      }
+      is SentencePlanApi.ApiOperationResult.Success -> {
+        OperationResult.Success(result.data)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/api/SentencePlanApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/api/SentencePlanApi.kt
@@ -1,9 +1,14 @@
 package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api
 
+import org.jboss.logging.Logger
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.VersionedEntity
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api.request.CreatePlanData
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api.response.CreatePlanResponse
-import java.util.*
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
 
 @Component
 class SentencePlanApi(
@@ -11,10 +16,42 @@ class SentencePlanApi(
   val apiProperties: SentencePlanApiProperties,
 ) {
 
-  fun createPlan(): CreatePlanResponse {
-    return CreatePlanResponse(
-      sentencePlanVersion = 0,
-      sentencePlanId = UUID.randomUUID(),
-    )
+  fun createPlan(createData: CreatePlanData): ApiOperationResult<VersionedEntity> {
+    return try {
+      val result = sentencePlanApiWebClient.post()
+        .uri(apiProperties.endpoints.create)
+        .body(BodyInserters.fromValue(createData))
+        .retrieve()
+        .bodyToMono(CreatePlanResponse::class.java)
+        .map {
+          VersionedEntity(
+            id = it.sentencePlanId,
+            version = it.sentencePlanVersion,
+            entityType = EntityType.PLAN,
+          )
+        }
+        .block()
+
+      result?.let {
+        ApiOperationResult.Success(it)
+      } ?: throw IllegalStateException("Unexpected error during createPlan")
+    } catch (ex: WebClientResponseException) {
+      ApiOperationResult.Failure("HTTP error during create plan: Status code ${ex.statusCode}, Response body: ${ex.responseBodyAsString}", ex)
+    } catch (ex: Exception) {
+      ApiOperationResult.Failure("Unexpected error during createPlan: ${ex.message}", ex)
+    }
+  }
+
+  sealed class ApiOperationResult<out T> {
+    data class Success<T>(val data: T) : ApiOperationResult<T>()
+
+    data class Failure<T>(
+      val errorMessage: String,
+      val cause: Throwable? = null,
+    ) : ApiOperationResult<T>() {
+      init {
+        Logger.getLogger(SentencePlanApi::class.java).error(errorMessage)
+      }
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/api/SentencePlanApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/api/SentencePlanApi.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api
 
-import org.jboss.logging.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
@@ -50,7 +50,7 @@ class SentencePlanApi(
       val cause: Throwable? = null,
     ) : ApiOperationResult<T>() {
       init {
-        Logger.getLogger(SentencePlanApi::class.java).error(errorMessage)
+        LoggerFactory.getLogger(SentencePlanApi::class.java).error(errorMessage)
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/api/request/CreatePlanData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/api/request/CreatePlanData.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api.request
+
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.UserDetails
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.entity.PlanType
+
+data class CreatePlanData(
+  val planType: PlanType,
+  val userDetails: UserDetails,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/api/response/CreatePlanResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/api/response/CreatePlanResponse.kt
@@ -1,9 +1,8 @@
 package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api.response
 
-import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.CreateResponse
 import java.util.*
 
 data class CreatePlanResponse(
   val sentencePlanId: UUID,
   val sentencePlanVersion: Long,
-) : CreateResponse
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/api/response/CreatePlanResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/api/response/CreatePlanResponse.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api.response
 
-import java.util.*
+import java.util.UUID
 
 data class CreatePlanResponse(
   val sentencePlanId: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/entity/PlanType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/entity/PlanType.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.entity
+
+enum class PlanType {
+  INITIAL,
+  REVIEW,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/OasysCoordinatorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/OasysCoordinatorService.kt
@@ -1,0 +1,81 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.features.ActionService
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.request.CreateAssessmentData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.CreateData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.OperationResult
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.UserDetails
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api.request.CreatePlanData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.OasysAssociationsService
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociation
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.controller.request.OasysCreateRequest
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.controller.response.OasysCreateResponse
+
+@Service
+class OasysCoordinatorService(
+  private val actionService: ActionService,
+  private val oasysAssociationsService: OasysAssociationsService,
+) {
+
+  private fun buildCreateData(requestData: OasysCreateRequest): CreateData {
+    return CreateData(
+      plan = CreatePlanData(
+        planType = requestData.planType,
+        userDetails = UserDetails(
+          id = requestData.userDetails.id,
+          name = requestData.userDetails.name,
+        ),
+      ),
+      assessment = CreateAssessmentData(
+        userDetails = UserDetails(
+          id = requestData.userDetails.id,
+          name = requestData.userDetails.name,
+        ),
+      ),
+    )
+  }
+
+  fun create(requestData: OasysCreateRequest): CreateOperationResult<OasysCreateResponse> {
+    oasysAssociationsService.ensureNoExistingAssociation(requestData.oasysAssessmentPk)
+      .onFailure { return CreateOperationResult.ConflictingAssociations("Cannot create due to conflicting associations: $it") }
+
+    when (val createAllResult = actionService.createAllEntities(buildCreateData(requestData))) {
+      is OperationResult.Failure -> return CreateOperationResult.Failure("Cannot create, creating entities failed: ${createAllResult.errorMessage}")
+      is OperationResult.Success -> {
+        val oasysCreateResponse = OasysCreateResponse()
+
+        for (versionedEntity in createAllResult.data) {
+          oasysCreateResponse.addVersionedEntity(versionedEntity)
+
+          oasysAssociationsService.storeAssociation(
+            OasysAssociation(
+              oasysAssessmentPk = requestData.oasysAssessmentPk,
+              regionPrisonCode = requestData.regionPrisonCode,
+              entityUuid = versionedEntity.id,
+              entityType = versionedEntity.entityType,
+            ),
+          ).onFailure {
+            // TODO: Probably want to do some kind of rollback here in future
+            return CreateOperationResult.Failure("Failed saving associations: $it")
+          }
+        }
+
+        return CreateOperationResult.Success(oasysCreateResponse)
+      }
+    }
+  }
+
+  sealed class CreateOperationResult<out T> {
+    data class Success<T>(val data: T) : CreateOperationResult<T>()
+
+    data class Failure<T>(
+      val errorMessage: String,
+      val cause: Throwable? = null,
+    ) : CreateOperationResult<T>()
+
+    data class ConflictingAssociations<T>(
+      val errorMessage: String,
+    ) : CreateOperationResult<T>()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/associations/repository/OasysAssociation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/associations/repository/OasysAssociation.kt
@@ -10,7 +10,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.time.Instant
 import java.time.format.DateTimeFormatter
-import java.util.*
+import java.util.UUID
 
 enum class EntityType {
   ASSESSMENT,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysCreateRequest.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.config.Constraints
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.entity.PlanType
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDetails
 
 data class OasysCreateRequest(
@@ -26,6 +27,10 @@ data class OasysCreateRequest(
   @Schema(description = "Region prison code", example = "111111")
   @Size(max = Constraints.REGION_PRISON_CODE_MAX_LENGTH)
   val regionPrisonCode: String? = null,
+
+  @Schema(description = "Sentence plan type", example = "INITIAL")
+  @Size(max = Constraints.REGION_PRISON_CODE_MAX_LENGTH)
+  val planType: PlanType,
 
   @Schema(description = "OASys User Details")
   @Valid

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/response/OasysCreateResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/response/OasysCreateResponse.kt
@@ -1,10 +1,27 @@
 package uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.controller.response
 
-import java.util.*
+import com.fasterxml.jackson.annotation.JsonInclude
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.VersionedEntity
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
+import java.util.UUID
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class OasysCreateResponse(
-  val sanAssessmentId: UUID,
-  val sanAssessmentVersion: Int,
-  val sentencePlanId: UUID? = null,
-  val sentencePlanVersion: Int? = null,
-)
+  var sanAssessmentId: UUID? = null,
+  var sanAssessmentVersion: Long? = null,
+  var sentencePlanId: UUID? = null,
+  var sentencePlanVersion: Long? = null,
+) {
+  fun addVersionedEntity(versionedEntity: VersionedEntity) {
+    when (versionedEntity.entityType) {
+      EntityType.PLAN -> {
+        this.sentencePlanId = versionedEntity.id
+        this.sentencePlanVersion = versionedEntity.version
+      }
+      EntityType.ASSESSMENT -> {
+        this.sanAssessmentId = versionedEntity.id
+        this.sanAssessmentVersion = versionedEntity.version
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/wiremock/mocks/SentencePlanApiMock.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/wiremock/mocks/SentencePlanApiMock.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.arnscoordinatorapi.wiremock.mocks
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import jakarta.annotation.PostConstruct
@@ -22,6 +23,9 @@ class SentencePlanApiMock(
   private fun createPlanStub() {
     wireMockServer.stubFor(
       post(urlEqualTo(wireMockProperties.paths.sentencePlan + apiProperties.endpoints.create))
+        .withRequestBody(matchingJsonPath("$.planType"))
+        .withRequestBody(matchingJsonPath("$.userDetails.id"))
+        .withRequestBody(matchingJsonPath("$.userDetails.name"))
         .willReturn(
           aResponse()
             .withStatus(200)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/wiremock/mocks/StrengthsAndNeedsApiMock.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/wiremock/mocks/StrengthsAndNeedsApiMock.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.arnscoordinatorapi.wiremock.mocks
 
 import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
@@ -22,6 +23,8 @@ class StrengthsAndNeedsApiMock(
   private fun createAssessmentStub() {
     wireMockServer.stubFor(
       post(urlEqualTo(wireMockProperties.paths.strengthAndNeeds + apiProperties.endpoints.create))
+        .withRequestBody(WireMock.matchingJsonPath("$.userDetails.id"))
+        .withRequestBody(WireMock.matchingJsonPath("$.userDetails.name"))
         .willReturn(
           aResponse()
             .withStatus(200)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/features/ActionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/features/ActionServiceTest.kt
@@ -1,0 +1,86 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.features
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.request.CreateAssessmentData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.*
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api.request.CreatePlanData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.entity.PlanType
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
+import java.util.*
+
+class ActionServiceTest {
+  private val component1 = mock(IntegrationService::class.java)
+  private val component2 = mock(IntegrationService::class.java)
+  private val actionService = ActionService(listOf(component1, component2))
+
+  private val userDetails = UserDetails(id = "user123", name = "John Doe")
+  private val planData = CreatePlanData(userDetails = userDetails, planType = PlanType.INITIAL)
+  private val assessmentData = CreateAssessmentData(userDetails = userDetails)
+
+  @Nested
+  inner class CreateAllEntities {
+
+    @Test
+    fun `should return success when all components return success`() {
+      val createData = CreateData(plan = planData, assessment = assessmentData)
+
+      val versionedEntity1 = VersionedEntity(UUID.randomUUID(), 0L, EntityType.PLAN)
+      val versionedEntity2 = VersionedEntity(UUID.randomUUID(), 0L, EntityType.ASSESSMENT)
+
+      `when`(component1.create(createData)).thenReturn(OperationResult.Success(versionedEntity1))
+      `when`(component2.create(createData)).thenReturn(OperationResult.Success(versionedEntity2))
+
+      val result = actionService.createAllEntities(createData)
+
+      assertTrue(result is OperationResult.Success)
+      val entities = (result as OperationResult.Success).data
+      assertEquals(2, entities.size)
+      assertTrue(entities.contains(versionedEntity1))
+      assertTrue(entities.contains(versionedEntity2))
+
+      verify(component1).create(createData)
+      verify(component2).create(createData)
+    }
+
+    @Test
+    fun `should return failure when any component returns failure`() {
+      val createData = CreateData(plan = planData, assessment = assessmentData)
+      val versionedEntity1 = VersionedEntity(UUID.randomUUID(), 1L, EntityType.PLAN)
+      val errorMessage = "Component 2 failed"
+
+      `when`(component1.create(createData)).thenReturn(OperationResult.Success(versionedEntity1))
+      `when`(component2.create(createData)).thenReturn(OperationResult.Failure(errorMessage))
+
+      val result = actionService.createAllEntities(createData)
+
+      assertTrue(result is OperationResult.Failure)
+      assertEquals(errorMessage, (result as OperationResult.Failure).errorMessage)
+
+      verify(component1).create(createData)
+      verify(component2).create(createData)
+    }
+
+    @Test
+    fun `should return failure when all components return failure`() {
+      val createData = CreateData(plan = planData, assessment = assessmentData)
+      val errorMessageComponent1 = "Component 1 failed"
+      val errorMessageComponent2 = "Component 2 failed"
+
+      `when`(component1.create(createData)).thenReturn(OperationResult.Failure(errorMessageComponent1))
+      `when`(component2.create(createData)).thenReturn(OperationResult.Failure(errorMessageComponent2))
+
+      val result = actionService.createAllEntities(createData)
+
+      assertTrue(result is OperationResult.Failure)
+      (result as OperationResult.Failure)
+      assertTrue(result.errorMessage.contains(errorMessageComponent1))
+      assertTrue(result.errorMessage.contains(errorMessageComponent2))
+
+      verify(component1).create(createData)
+      verify(component2).create(createData)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/features/ActionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/features/ActionServiceTest.kt
@@ -1,15 +1,22 @@
 package uk.gov.justice.digital.hmpps.arnscoordinatorapi.features
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.request.CreateAssessmentData
-import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.*
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.CreateData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.IntegrationService
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.OperationResult
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.UserDetails
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.VersionedEntity
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api.request.CreatePlanData
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.entity.PlanType
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
-import java.util.*
+import java.util.UUID
 
 class ActionServiceTest {
   private val component1 = mock(IntegrationService::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/AssessmentServiceTest.kt
@@ -19,7 +19,7 @@ import java.util.UUID
 class AssessmentServiceTest {
   private val strengthsAndNeedsApi = mock(StrengthsAndNeedsApi::class.java)
   private val assessmentService = AssessmentService(strengthsAndNeedsApi)
-  val userDetails = UserDetails(id = "user123", name = "John Doe")
+  private val userDetails = UserDetails(id = "user123", name = "John Doe")
 
   @Nested
   inner class Create {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/AssessmentServiceTest.kt
@@ -1,0 +1,66 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.StrengthsAndNeedsApi
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api.request.CreateAssessmentData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.CreateData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.OperationResult
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.UserDetails
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.VersionedEntity
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
+import java.util.UUID
+
+class AssessmentServiceTest {
+  private val strengthsAndNeedsApi = mock(StrengthsAndNeedsApi::class.java)
+  private val assessmentService = AssessmentService(strengthsAndNeedsApi)
+  val userDetails = UserDetails(id = "user123", name = "John Doe")
+
+  @Nested
+  inner class Create {
+
+    @Test
+    fun `should return success when StrengthsAndNeedsApi returns success`() {
+      val createAssessmentData = CreateAssessmentData(userDetails = userDetails)
+      val createData = CreateData(
+        assessment = createAssessmentData,
+      )
+      val versionedEntity = VersionedEntity(
+        id = UUID.randomUUID(),
+        version = 1L,
+        entityType = EntityType.ASSESSMENT,
+      )
+      val successResult = StrengthsAndNeedsApi.ApiOperationResult.Success(versionedEntity)
+
+      `when`(strengthsAndNeedsApi.createAssessment(createAssessmentData)).thenReturn(successResult)
+
+      val result = assessmentService.create(createData)
+
+      assertTrue(result is OperationResult.Success)
+      assertEquals(versionedEntity, (result as OperationResult.Success).data)
+      verify(strengthsAndNeedsApi).createAssessment(createAssessmentData)
+    }
+
+    @Test
+    fun `should return failure when StrengthsAndNeedsApi returns failure`() {
+      val createAssessmentData = CreateAssessmentData(userDetails = userDetails)
+      val createData = CreateData(
+        assessment = createAssessmentData,
+      )
+      val failureResult = StrengthsAndNeedsApi.ApiOperationResult.Failure<Nothing>("An error occurred")
+
+      `when`(strengthsAndNeedsApi.createAssessment(createAssessmentData)).thenReturn(failureResult)
+
+      val result = assessmentService.create(createData)
+
+      assertTrue(result is OperationResult.Failure)
+      assertEquals("An error occurred", (result as OperationResult.Failure).errorMessage)
+      verify(strengthsAndNeedsApi).createAssessment(createAssessmentData) // Correctly verifying the mock
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/PlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/PlanServiceTest.kt
@@ -1,0 +1,75 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.CreateData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.OperationResult
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.UserDetails
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.VersionedEntity
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api.SentencePlanApi
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api.request.CreatePlanData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.entity.PlanType
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
+import java.util.UUID
+
+class PlanServiceTest {
+  private val sentencePlanApi = mock(SentencePlanApi::class.java)
+  private val planService = PlanService(sentencePlanApi)
+  private val userDetails = UserDetails(id = "user123", name = "John Doe")
+
+  @Nested
+  inner class Create {
+
+    @Test
+    fun `should return success when SentencePlanApi returns success`() {
+      val createPlanData = CreatePlanData(
+        userDetails = userDetails,
+        planType = PlanType.INITIAL,
+      )
+      val createData = CreateData(
+        plan = createPlanData,
+      )
+      val versionedEntity = VersionedEntity(
+        id = UUID.randomUUID(),
+        version = 1L,
+        entityType = EntityType.PLAN,
+      )
+      val successResult = SentencePlanApi.ApiOperationResult.Success(versionedEntity)
+
+      `when`(sentencePlanApi.createPlan(createPlanData)).thenReturn(successResult)
+
+      val result = planService.create(createData)
+
+      assertTrue(result is OperationResult.Success)
+      assertEquals(versionedEntity, (result as OperationResult.Success).data)
+
+      verify(sentencePlanApi).createPlan(createPlanData)
+    }
+
+    @Test
+    fun `should return failure when SentencePlanApi returns failure`() {
+      val createPlanData = CreatePlanData(
+        userDetails = userDetails,
+        planType = PlanType.INITIAL,
+      )
+      val createData = CreateData(
+        plan = createPlanData,
+      )
+      val failureResult = SentencePlanApi.ApiOperationResult.Failure<Nothing>("Failed to create plan")
+
+      `when`(sentencePlanApi.createPlan(createPlanData)).thenReturn(failureResult)
+
+      val result = planService.create(createData)
+
+      assertTrue(result is OperationResult.Failure)
+      assertEquals("Failed to create plan", (result as OperationResult.Failure).errorMessage)
+
+      verify(sentencePlanApi).createPlan(createPlanData)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/OasysCoordinatorServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/OasysCoordinatorServiceTest.kt
@@ -1,0 +1,122 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoMoreInteractions
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.features.ActionService
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.CreateData
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.OperationResult
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.VersionedEntity
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.entity.PlanType
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.OasysAssociationsService
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociation
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.controller.request.OasysCreateRequest
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDetails
+import java.util.UUID
+
+class OasysCoordinatorServiceTest {
+  private val actionService = mock(ActionService::class.java)
+  private val oasysAssociationsService = mock(OasysAssociationsService::class.java)
+  private val oasysCoordinatorService = OasysCoordinatorService(actionService, oasysAssociationsService)
+
+  val requestData = OasysCreateRequest(
+    oasysAssessmentPk = "XY/12456",
+    planType = PlanType.INITIAL,
+    regionPrisonCode = "123",
+    userDetails = OasysUserDetails(id = "user123", name = "John Doe"),
+  )
+
+  @Nested
+  inner class Create {
+
+    @Test
+    fun `should return success when all services succeed`() {
+      val versionedEntityPlan = VersionedEntity(UUID.randomUUID(), 1L, EntityType.PLAN)
+      val versionedEntityAssessment = VersionedEntity(UUID.randomUUID(), 2L, EntityType.ASSESSMENT)
+
+      `when`(oasysAssociationsService.ensureNoExistingAssociation(requestData.oasysAssessmentPk))
+        .thenReturn(OperationResult.Success(Unit))
+      `when`(actionService.createAllEntities(any<CreateData>()))
+        .thenReturn(OperationResult.Success(listOf(versionedEntityPlan, versionedEntityAssessment)))
+      `when`(oasysAssociationsService.storeAssociation(any<OasysAssociation>()))
+        .thenReturn(OperationResult.Success(Unit))
+
+      val result = oasysCoordinatorService.create(requestData)
+
+      assertTrue(result is OasysCoordinatorService.CreateOperationResult.Success)
+      val response = (result as OasysCoordinatorService.CreateOperationResult.Success).data
+
+      assertEquals(versionedEntityPlan.id, response.sentencePlanId)
+      assertEquals(versionedEntityPlan.version, response.sentencePlanVersion)
+      assertEquals(versionedEntityAssessment.id, response.sanAssessmentId)
+      assertEquals(versionedEntityAssessment.version, response.sanAssessmentVersion)
+
+      verify(oasysAssociationsService).ensureNoExistingAssociation(requestData.oasysAssessmentPk)
+      verify(actionService).createAllEntities(any<CreateData>())
+      verify(oasysAssociationsService, times(2)).storeAssociation(any<OasysAssociation>())
+    }
+
+    @Test
+    fun `should return failure when actionService fails to create entities`() {
+      `when`(oasysAssociationsService.ensureNoExistingAssociation(requestData.oasysAssessmentPk))
+        .thenReturn(OperationResult.Success(Unit))
+      `when`(actionService.createAllEntities(any<CreateData>()))
+        .thenReturn(OperationResult.Failure("Failed to create entities"))
+
+      val result = oasysCoordinatorService.create(requestData)
+
+      assertTrue(result is OasysCoordinatorService.CreateOperationResult.Failure)
+      val failureMessage = (result as OasysCoordinatorService.CreateOperationResult.Failure).errorMessage
+      assertEquals("Cannot create, creating entities failed: Failed to create entities", failureMessage)
+
+      verify(oasysAssociationsService).ensureNoExistingAssociation(requestData.oasysAssessmentPk)
+      verify(actionService).createAllEntities(any())
+    }
+
+    @Test
+    fun `should return failure due to conflicting associations`() {
+      `when`(oasysAssociationsService.ensureNoExistingAssociation(requestData.oasysAssessmentPk))
+        .thenReturn(OperationResult.Failure("Conflicting association"))
+
+      val result = oasysCoordinatorService.create(requestData)
+
+      assertTrue(result is OasysCoordinatorService.CreateOperationResult.ConflictingAssociations)
+      val failureMessage = (result as OasysCoordinatorService.CreateOperationResult.ConflictingAssociations).errorMessage
+      assertEquals("Cannot create due to conflicting associations: Conflicting association", failureMessage)
+
+      verify(oasysAssociationsService).ensureNoExistingAssociation(requestData.oasysAssessmentPk)
+      verifyNoMoreInteractions(actionService) // Ensure actionService is not called
+    }
+
+    @Test
+    fun `should return failure when association storage fails after entity creation`() {
+      val versionedEntityPlan = VersionedEntity(UUID.randomUUID(), 1L, EntityType.PLAN)
+      val versionedEntityAssessment = VersionedEntity(UUID.randomUUID(), 2L, EntityType.ASSESSMENT)
+
+      `when`(oasysAssociationsService.ensureNoExistingAssociation(requestData.oasysAssessmentPk))
+        .thenReturn(OperationResult.Success(Unit))
+      `when`(actionService.createAllEntities(any<CreateData>()))
+        .thenReturn(OperationResult.Success(listOf(versionedEntityPlan, versionedEntityAssessment)))
+      `when`(oasysAssociationsService.storeAssociation(any<OasysAssociation>()))
+        .thenReturn(OperationResult.Failure("Failed to store association"))
+
+      val result = oasysCoordinatorService.create(requestData)
+
+      assertTrue(result is OasysCoordinatorService.CreateOperationResult.Failure)
+      val failureMessage = (result as OasysCoordinatorService.CreateOperationResult.Failure).errorMessage
+      assertEquals("Failed saving associations: Failed to store association", failureMessage)
+
+      verify(oasysAssociationsService).ensureNoExistingAssociation(requestData.oasysAssessmentPk)
+      verify(actionService).createAllEntities(any<CreateData>())
+      verify(oasysAssociationsService).storeAssociation(any<OasysAssociation>())
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/associations/OasysAssociationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/associations/OasysAssociationsServiceTest.kt
@@ -1,3 +1,5 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations
+
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -8,7 +10,6 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.OperationResult
-import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.OasysAssociationsService
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociation
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociationRepository


### PR DESCRIPTION
- Add OasysController 'create' logic
- Add OasysCoordinatorService for translating and coordinating and instructing `ActionService`) and storing OASys specific associations
- Added ActionService for performing actions across the systems components (Sentence Plan, SAN)
- Added a bunch of unit tests