### PR TITLE
Update app to use one clientid/secret for each API

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_PASSWORD: postgres
 
   hmpps-auth:
-    image: quay.io/hmpps/hmpps-auth:latest
+    image: quay.io/hmpps/hmpps-auth:2024-10-02.25761.db2ce3c
     healthcheck:
       test: ["CMD", "curl", "-f", "http://hmpps-auth:9090/auth/health"]
       interval: 5s
@@ -49,11 +49,9 @@ services:
     environment:
       SERVER_PORT: 8080
       APP_DB_ENDPOINT: postgres:5432
-      HMPPS_AUTH_BASE_URL: http://hmpps-auth:9090
+      HMPPS_AUTH_BASE_URL: http://hmpps-auth:9090/auth
       SAN_API_BASE_URL: http://san-api:3050
-      # TODO: Need to get some proper credentials for below
-      SAN_API_CLIENT_ID: hmpps-strengths-and-needs-ui-client
-      SAN_API_CLIENT_SECRET: clientsecret
       SP_API_BASE_URL: http://sp-api:3060
-      SP_API_CLIENT_ID: hmpps-strengths-and-needs-ui-client
-      SP_API_CLIENT_SECRET: clientsecret
+      # TODO: Need to get some proper credentials for below
+      CLIENT_ID: hmpps-assess-risks-and-needs-oastub-ui
+      CLIENT_SECRET: clientsecret

--- a/helm_deploy/hmpps-assess-risks-and-needs-coordinator-api/values.yaml
+++ b/helm_deploy/hmpps-assess-risks-and-needs-coordinator-api/values.yaml
@@ -29,6 +29,8 @@ generic-service:
   namespace_secrets:
     hmpps-assess-risks-and-needs-coordinator-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
+      CLIENT_ID: "COORDINATOR_CLIENT_ID"
+      CLIENT_SECRET: "COORDINATOR_CLIENT_SECRET"
 
     hmpps-assess-risks-and-needs-integrations-rds-instance:
       APP_DB_ENDPOINT: rds_instance_endpoint

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,14 +36,14 @@ spring:
         registration:
           san-api:
             provider: hmpps-auth
-            client-id: ${san-api.client.id}
-            client-secret: ${san-api.client.secret}
+            client-id: ${app.client.id}
+            client-secret: ${app.client.secret}
             authorization-grant-type: client_credentials
             scope: read, write
           sentence-plan-api:
             provider: hmpps-auth
-            client-id: ${sp-api.client.id}
-            client-secret: ${sp-api.client.secret}
+            client-id: ${app.client.id}
+            client-secret: ${app.client.secret}
             authorization-grant-type: client_credentials
             scope: read, write
 
@@ -75,6 +75,9 @@ app:
       name: coordinator
     username: postgres
     password: postgres
+  client:
+    id: ${CLIENT_ID}
+    secret: ${CLIENT_SECRET}
 
 server:
   port: 8080


### PR DESCRIPTION
- Update app to just use a `CLIENT_ID` and `CLIENT_SECRET` rather than per-API client credentials
- Added `COORDINATOR_CLIENT_ID` and `COORDINATOR_CLIENT_SECRET` for using the newly created  auth credentials