### PR TITLE
Don't require unused environment variables when strategy disabled

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/WebClientConfiguration.kt
@@ -24,7 +24,7 @@ class WebClientConfiguration(
   fun sanApiWebClient(
     authorizedClientManager: OAuth2AuthorizedClientManager,
     builder: WebClient.Builder,
-    @Value("\${app.services.strengths-and-needs-api.base-url:}") sanApiBaseUri: String,
+    @Value("\${app.services.strengths-and-needs-api.base-url}") sanApiBaseUri: String,
   ): WebClient =
     builder.authorisedWebClient(authorizedClientManager, registrationId = "san-api", url = sanApiBaseUri, timeout)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/WebClientConfiguration.kt
@@ -20,7 +20,7 @@ class WebClientConfiguration(
   fun hmppsAuthHealthWebClient(builder: WebClient.Builder): WebClient = builder.healthWebClient(hmppsAuthBaseUri, healthTimeout)
 
   @Bean
-  @ConditionalOnProperty(name = ["app.strategies.assessment"], havingValue = "true", matchIfMissing = true)
+  @ConditionalOnProperty(name = ["app.strategies.assessment"], havingValue = "true")
   fun sanApiWebClient(
     authorizedClientManager: OAuth2AuthorizedClientManager,
     builder: WebClient.Builder,
@@ -29,7 +29,7 @@ class WebClientConfiguration(
     builder.authorisedWebClient(authorizedClientManager, registrationId = "san-api", url = sanApiBaseUri, timeout)
 
   @Bean
-  @ConditionalOnProperty(name = ["app.strategies.plan"], havingValue = "true", matchIfMissing = true)
+  @ConditionalOnProperty(name = ["app.strategies.plan"], havingValue = "true")
   fun sentencePlanApiWebClient(
     authorizedClientManager: OAuth2AuthorizedClientManager,
     builder: WebClient.Builder,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/StrengthsAndNeedsApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/StrengthsAndNeedsApi.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.assessment.api
 
 import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
@@ -13,6 +14,7 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.reposi
 import java.util.UUID
 
 @Component
+@ConditionalOnProperty(name = ["app.strategies.assessment"], havingValue = "true", matchIfMissing = true)
 class StrengthsAndNeedsApi(
   val sanApiWebClient: WebClient,
   val apiProperties: StrengthsAndNeedsApiProperties,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/StrengthsAndNeedsApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/assessment/api/StrengthsAndNeedsApi.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.reposi
 import java.util.UUID
 
 @Component
-@ConditionalOnProperty(name = ["app.strategies.assessment"], havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = ["app.strategies.assessment"], havingValue = "true")
 class StrengthsAndNeedsApi(
   val sanApiWebClient: WebClient,
   val apiProperties: StrengthsAndNeedsApiProperties,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/api/SentencePlanApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/api/SentencePlanApi.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.reposi
 import java.util.UUID
 
 @Component
-@ConditionalOnProperty(name = ["app.strategies.plan"], havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = ["app.strategies.plan"], havingValue = "true")
 class SentencePlanApi(
   val sentencePlanApiWebClient: WebClient,
   val apiProperties: SentencePlanApiProperties,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/api/SentencePlanApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/plan/api/SentencePlanApi.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.api
 
 import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
@@ -13,6 +14,7 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.reposi
 import java.util.UUID
 
 @Component
+@ConditionalOnProperty(name = ["app.strategies.plan"], havingValue = "true", matchIfMissing = true)
 class SentencePlanApi(
   val sentencePlanApiWebClient: WebClient,
   val apiProperties: SentencePlanApiProperties,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/strategy/AssessmentStrategy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/strategy/AssessmentStrategy.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.reposi
 import java.util.UUID
 
 @Component
-@ConditionalOnProperty(name = ["app.strategies.assessment"], havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = ["app.strategies.assessment"], havingValue = "true")
 class AssessmentStrategy(
   private val strengthsAndNeedsApi: StrengthsAndNeedsApi,
 ) : EntityStrategy {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/strategy/PlanStrategy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/strategy/PlanStrategy.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.reposi
 import java.util.UUID
 
 @Service
-@ConditionalOnProperty(name = ["app.strategies.plan"], havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = ["app.strategies.plan"], havingValue = "true")
 class PlanStrategy(
   private val sentencePlanApi: SentencePlanApi,
 ) : EntityStrategy {


### PR DESCRIPTION
- Remove the need to provide unused environment variables when disabling a strategy (i.e., no need to set the SP_API_URL if disabled the `plan` strategy