### PR TITLE
SP2-886 - Coordinator Input Validation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler.kt
@@ -31,7 +31,8 @@ class HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler {
 
   @ExceptionHandler(MethodArgumentNotValidException::class)
   fun handleArgumentNotValidationException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
-    val parsedErrors = e.bindingResult.fieldErrors.map{ "${it.codes?.get(1)?.substringAfter(".")} - ${it.defaultMessage}" }
+    val parsedErrors = e.bindingResult.fieldErrors
+      .map{ "${it.codes?.get(0)?.substringAfter("#")?.substringAfter(".")} - ${it.defaultMessage}" }
 
     return ResponseEntity
       .status(BAD_REQUEST)
@@ -51,7 +52,7 @@ class HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler {
     val parsedErrors = e.allValidationResults
       .map { it.resolvableErrors }
       .flatMap { it }
-      .map { "${it.codes?.get(1)?.substringAfter(".")} - ${it.defaultMessage}" }
+      .map { "${it.codes?.get(0)?.substringAfter("#")?.substringAfter(".")} - ${it.defaultMessage}" }
 
     return ResponseEntity
       .status(BAD_REQUEST)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler.kt
@@ -32,7 +32,7 @@ class HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler {
   @ExceptionHandler(MethodArgumentNotValidException::class)
   fun handleArgumentNotValidationException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
     val parsedErrors = e.bindingResult.fieldErrors
-      .map{ "${it.codes?.get(0)?.substringAfter("#")?.substringAfter(".")} - ${it.defaultMessage}" }
+      .map { "${it.codes?.get(0)?.substringAfter("#")?.substringAfter(".")} - ${it.defaultMessage}" }
 
     return ResponseEntity
       .status(BAD_REQUEST)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler.kt
@@ -9,10 +9,13 @@ import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.HandlerMethodValidationException
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
+import java.util.stream.Collectors
 
 @RestControllerAdvice
 class HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler {
@@ -26,6 +29,28 @@ class HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler {
         developerMessage = e.message,
       ),
     ).also { log.info("Validation exception: {}", e.message) }
+
+  @ExceptionHandler(MethodArgumentNotValidException::class)
+  fun handleArgumentNotValidationException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> = ResponseEntity
+    .status(BAD_REQUEST)
+    .body(
+      ErrorResponse(
+        status = BAD_REQUEST,
+        userMessage = "Validation failure: ${(e.bindingResult.fieldErrors.map { "${it.field} - ${it.defaultMessage}" })}",
+        developerMessage = "${(e.bindingResult.fieldErrors.map { "${it.field} - ${it.defaultMessage}" })}",
+      ),
+    ).also { log.info("Validation exceptions: {}", e.bindingResult.fieldErrors.map { "${it.field} - ${it.defaultMessage}" }) }
+
+  @ExceptionHandler(HandlerMethodValidationException::class)
+  fun handlerMethodNotValidationException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> = ResponseEntity
+    .status(BAD_REQUEST)
+    .body(
+      ErrorResponse(
+        status = BAD_REQUEST,
+        userMessage = "Validation failure: ${(e.bindingResult.fieldErrors.map { "${it.field} - ${it.defaultMessage}" })}",
+        developerMessage = "${(e.bindingResult.fieldErrors.map { "${it.field} - ${it.defaultMessage}" })}",
+      ),
+    ).also { log.info("Validation exceptions: {}", e.bindingResult.fieldErrors.map { "${it.field} - ${it.defaultMessage}" }) }
 
   @ExceptionHandler(HttpMessageNotReadableException::class)
   fun handleNoRequestException(e: HttpMessageNotReadableException): ResponseEntity<ErrorResponse> = ResponseEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler.kt
@@ -30,15 +30,21 @@ class HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler {
     ).also { log.info("Validation exception: {}", e.message) }
 
   @ExceptionHandler(MethodArgumentNotValidException::class)
-  fun handleArgumentNotValidationException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> = ResponseEntity
-    .status(BAD_REQUEST)
-    .body(
-      ErrorResponse(
-        status = BAD_REQUEST,
-        userMessage = "Validation failure: ${(e.bindingResult.fieldErrors.map { "${it.codes?.get(1)} - ${it.defaultMessage}" })}",
-        developerMessage = "${(e.bindingResult.fieldErrors.map { "${it.codes?.get(1)} - ${it.defaultMessage}" })}",
-      ),
-    ).also { log.info("MethodArgumentNotValidException: {}", e.bindingResult.fieldErrors.map { "${it.codes?.get(1)} - ${it.defaultMessage}" }) }
+  fun handleArgumentNotValidationException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
+    val parsedErrors = e.bindingResult.fieldErrors.map{ "${it.codes?.get(1)?.substringAfter(".")} - ${it.defaultMessage}" }
+
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST,
+          userMessage = "Validation failure: $parsedErrors",
+          developerMessage = "$parsedErrors",
+        ),
+      ).also {
+        log.info("MethodArgumentNotValidException: {}", "$parsedErrors")
+      }
+  }
 
   @ExceptionHandler(HandlerMethodValidationException::class)
   fun handlerMethodNotValidationException(e: HandlerMethodValidationException): ResponseEntity<ErrorResponse> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/config/HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler.kt
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.HandlerMethodValidationException
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
-import java.util.stream.Collectors
 
 @RestControllerAdvice
 class HmppsAssessRisksAndNeedsCoordinatorApiExceptionHandler {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/OasysController.kt
@@ -61,7 +61,7 @@ class OasysController(
     ],
   )
   fun get(
-    @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
+    @Parameter(description = "OASys Assessment PK", required = true, example = "1001")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
     @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
@@ -229,7 +229,7 @@ class OasysController(
     ],
   )
   fun sign(
-    @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
+    @Parameter(description = "OASys Assessment PK", required = true, example = "1001")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
     @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
@@ -290,7 +290,7 @@ class OasysController(
     ],
   )
   fun counterSign(
-    @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
+    @Parameter(description = "OASys Assessment PK", required = true, example = "1001")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
     @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
@@ -350,7 +350,7 @@ class OasysController(
     ],
   )
   fun lock(
-    @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
+    @Parameter(description = "OASys Assessment PK", required = true, example = "1001")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
     @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
@@ -413,7 +413,7 @@ class OasysController(
     ],
   )
   fun rollback(
-    @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
+    @Parameter(description = "OASys Assessment PK", required = true, example = "1001")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
     @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
@@ -475,7 +475,7 @@ class OasysController(
     ],
   )
   fun softDelete(
-    @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
+    @Parameter(description = "OASys Assessment PK", required = true, example = "1001")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
     @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
@@ -536,7 +536,7 @@ class OasysController(
     ],
   )
   fun undelete(
-    @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
+    @Parameter(description = "OASys Assessment PK", required = true, example = "1001")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
     @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
@@ -596,7 +596,7 @@ class OasysController(
     ],
   )
   fun associations(
-    @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
+    @Parameter(description = "OASys Assessment PK", required = true, example = "1001")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
     @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/OasysController.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -63,6 +64,7 @@ class OasysController(
     @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+    @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
     @Valid oasysAssessmentPK: String,
   ): ResponseEntity<*> {
     return when (val result = oasysCoordinatorService.get(oasysAssessmentPK)) {
@@ -230,6 +232,7 @@ class OasysController(
     @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+    @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
     @Valid oasysAssessmentPK: String,
     @RequestBody @Valid request: OasysSignRequest,
   ): ResponseEntity<Any> {
@@ -290,6 +293,7 @@ class OasysController(
     @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+    @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
     @Valid oasysAssessmentPK: String,
     @RequestBody @Valid request: OasysCounterSignRequest,
   ): ResponseEntity<Any> {
@@ -349,6 +353,7 @@ class OasysController(
     @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+    @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
     @Valid
     oasysAssessmentPK: String,
     @RequestBody @Valid
@@ -411,6 +416,7 @@ class OasysController(
     @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+    @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
     @Valid oasysAssessmentPK: String,
     @RequestBody @Valid
     request: OasysRollbackRequest,
@@ -472,6 +478,7 @@ class OasysController(
     @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+    @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
     @Valid oasysAssessmentPK: String,
     @RequestBody @Valid request: OasysGenericRequest,
   ): ResponseEntity<Any> {
@@ -532,6 +539,7 @@ class OasysController(
     @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+    @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
     @Valid oasysAssessmentPK: String,
     @RequestBody @Valid request: OasysGenericRequest,
   ): ResponseEntity<Any> {
@@ -591,6 +599,7 @@ class OasysController(
     @Parameter(description = "OASys Assessment PK", required = true, example = "oasys-pk-goes-here")
     @PathVariable
     @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+    @Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
     @Valid oasysAssessmentPK: String,
   ): ResponseEntity<Any> {
     return when (val result = oasysCoordinatorService.getAssociations(oasysAssessmentPK)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysCounterSignRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysCounterSignRequest.kt
@@ -8,17 +8,17 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDet
 
 data class OasysCounterSignRequest(
   @Schema(description = "The SAN Assessment version number that was returned from the Sign Assessment API call.", example = "2")
-  @PositiveOrZero
+  @field:PositiveOrZero
   val sanVersionNumber: Long?,
 
   @Schema(description = "The Sentence Plan version number that was returned from the Sign Plan API call.", example = "2")
-  @PositiveOrZero
+  @field:PositiveOrZero
   val sentencePlanVersionNumber: Long?,
 
   @Schema(description = "Indicates what type of case this is")
   val outcome: CounterSignOutcome,
 
   @Schema(description = "OASys User Details")
-  @Valid
+  @field:Valid
   val userDetails: OasysUserDetails,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysCreateRequest.kt
@@ -12,19 +12,19 @@ data class OasysCreateRequest(
   @Schema(
     required = true,
     description = "OASys Assessment PK to create an association for",
-    example = "CY/12ZX56",
+    example = "123456",
   )
   @field:Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
-  @field:Pattern(regexp = "^[0-9]{1,15}$", message = "Must only contain numeric characters")
+  @field:Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
   val oasysAssessmentPk: String,
 
   @Schema(
     description = "(Optional) Provide an old OASys Assessment PK. " +
       "The new OASys Assessment PK will be associated to clones of the previous associated entities",
-    example = "CY/12ZX56",
+    example = "123456",
   )
   @field:Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
-  @field:Pattern(regexp = "^[0-9]{1,15}$", message = "Must only contain numeric characters")
+  @field:Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
   val previousOasysAssessmentPk: String? = null,
 
   @Schema(description = "Region prison code", example = "111111")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysCreateRequest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.controller.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.config.Constraints
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.entity.PlanType
@@ -13,7 +14,8 @@ data class OasysCreateRequest(
     description = "OASys Assessment PK to create an association for",
     example = "CY/12ZX56",
   )
-  @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+  @field:Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+  @field:Pattern(regexp = "^[0-9]{1,15}$", message = "Must only contain numeric characters")
   val oasysAssessmentPk: String,
 
   @Schema(
@@ -21,17 +23,18 @@ data class OasysCreateRequest(
       "The new OASys Assessment PK will be associated to clones of the previous associated entities",
     example = "CY/12ZX56",
   )
-  @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+  @field:Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+  @field:Pattern(regexp = "^[0-9]{1,15}$", message = "Must only contain numeric characters")
   val previousOasysAssessmentPk: String? = null,
 
   @Schema(description = "Region prison code", example = "111111")
-  @Size(max = Constraints.REGION_PRISON_CODE_MAX_LENGTH)
+  @field:Size(max = Constraints.REGION_PRISON_CODE_MAX_LENGTH)
   val regionPrisonCode: String? = null,
 
   @Schema(description = "Sentence plan type", example = "INITIAL")
   val planType: PlanType,
 
   @Schema(description = "OASys User Details")
-  @Valid
+  @field:Valid
   val userDetails: OasysUserDetails,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysGenericRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysGenericRequest.kt
@@ -6,6 +6,6 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDet
 
 data class OasysGenericRequest(
   @Schema(description = "OASys User Details")
-  @Valid
+  @field:Valid
   val userDetails: OasysUserDetails,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysMergeRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysMergeRequest.kt
@@ -8,11 +8,11 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDet
 
 data class OasysMergeRequest(
   @Schema(description = "List of OASys Assessment PKs pairs to merge")
-  @Valid
-  @NotEmpty
+  @field:Valid
+  @field:NotEmpty
   val merge: List<OasysTransferAssociation>,
 
   @Schema(description = "OASys User")
-  @Valid
+  @field:Valid
   val userDetails: OasysUserDetails,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysRollbackRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysRollbackRequest.kt
@@ -7,14 +7,14 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDet
 
 data class OasysRollbackRequest(
   @Schema(description = "The SAN Assessment version number that was returned from the Sign Assessment API call.", example = "2")
-  @PositiveOrZero
+  @field:PositiveOrZero
   val sanVersionNumber: Long?,
 
   @Schema(description = "The plan version number that was returned from the Sign Plan API call.", example = "2")
-  @PositiveOrZero
+  @field:PositiveOrZero
   val sentencePlanVersionNumber: Long?,
 
   @Schema(description = "OASys User Details")
-  @Valid
+  @field:Valid
   val userDetails: OasysUserDetails,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysSignRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysSignRequest.kt
@@ -7,10 +7,10 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDet
 
 data class OasysSignRequest(
   @Schema(description = "Indicates the signing type")
-  @Valid
+  @field:Valid
   val signType: SignType,
 
   @Schema(description = "OASys User")
-  @Valid
+  @field:Valid
   val userDetails: OasysUserDetails,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysSignRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/controller/request/OasysSignRequest.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDet
 
 data class OasysSignRequest(
   @Schema(description = "Indicates the signing type")
-  @field:Valid
   val signType: SignType,
 
   @Schema(description = "OASys User")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/entity/OasysTransferAssociation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/entity/OasysTransferAssociation.kt
@@ -1,12 +1,15 @@
 package uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity
 
+import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.config.Constraints
 
 data class OasysTransferAssociation(
-  @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+  @field:Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+  @field:Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
   val oldOasysAssessmentPK: String,
 
-  @Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+  @field:Size(min = Constraints.OASYS_PK_MIN_LENGTH, max = Constraints.OASYS_PK_MAX_LENGTH)
+  @field:Pattern(regexp = "^\\d+$", message = "Must only contain numeric characters")
   val newOasysAssessmentPK: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/entity/OasysUserDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/entity/OasysUserDetails.kt
@@ -8,11 +8,11 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entit
 
 data class OasysUserDetails(
   @Schema(description = "User ID", example = "RB123XYZ")
-  @Size(max = Constraints.OASYS_USER_ID_MAX_LENGTH)
+  @field:Size(max = Constraints.OASYS_USER_ID_MAX_LENGTH)
   val id: String = "",
 
   @Schema(description = "User's full name", example = "John Doe")
-  @Size(max = Constraints.OASYS_USER_NAME_MAX_LENGTH)
+  @field:Size(max = Constraints.OASYS_USER_NAME_MAX_LENGTH)
   val name: String = "",
 ) {
   fun intoUserDetails() = UserDetails(id, name, UserType.OASYS)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/AssociationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/AssociationsTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.test.web.reactive.server.expectBody
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
+
+class AssociationsTest : IntegrationTestBase() {
+
+  @Test
+  fun `it returns 400 when validation errors occur in the path parameter`() {
+    val sixteenCharPk = "012345678901234A"
+
+    val response = webTestClient.get().uri("/oasys/$sixteenCharPk/associations")
+      .header(HttpHeaders.CONTENT_TYPE, "application/json")
+      .headers(setAuthorisation(roles = listOf("ROLE_STRENGTHS_AND_NEEDS_OASYS")))
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody<ErrorResponse>()
+      .returnResult()
+
+    assertThat(response.responseBody?.developerMessage).contains("oasysAssessmentPK - Must only contain numeric characters")
+    assertThat(response.responseBody?.developerMessage).contains("oasysAssessmentPK - size must be between 1 and 15")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/CounterSignTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/CounterSignTest.kt
@@ -164,7 +164,7 @@ class CounterSignTest : IntegrationTestBase() {
     val sixteenCharId = "ABCDEFGHIJKLMNOP"
     val longName = "SomebodyHasAReallyLongFirstName ItsAlmostAsLongAsTheirSurnameButNotQuite"
 
-    val response = webTestClient.post().uri("/oasys/${sixteenCharPk}/counter-sign")
+    val response = webTestClient.post().uri("/oasys/$sixteenCharPk/counter-sign")
       .header(HttpHeaders.CONTENT_TYPE, "application/json")
       .headers(setAuthorisation(roles = listOf("ROLE_STRENGTHS_AND_NEEDS_OASYS")))
       .bodyValue(
@@ -213,7 +213,7 @@ class CounterSignTest : IntegrationTestBase() {
   fun `it returns 400 when validation errors occur in parameter only`() {
     val sixteenCharPk = "0123456789012345"
 
-    val response = webTestClient.post().uri("/oasys/${sixteenCharPk}/counter-sign")
+    val response = webTestClient.post().uri("/oasys/$sixteenCharPk/counter-sign")
       .header(HttpHeaders.CONTENT_TYPE, "application/json")
       .headers(setAuthorisation(roles = listOf("ROLE_STRENGTHS_AND_NEEDS_OASYS")))
       .bodyValue(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/CounterSignTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/CounterSignTest.kt
@@ -157,4 +157,79 @@ class CounterSignTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isNotFound
   }
+
+  @Test
+  fun `it returns 400 when validation errors occur in both parameter and body`() {
+    val sixteenCharPk = "0123456789012345"
+    val sixteenCharId = "ABCDEFGHIJKLMNOP"
+    val longName = "SomebodyHasAReallyLongFirstName ItsAlmostAsLongAsTheirSurnameButNotQuite"
+
+    val response = webTestClient.post().uri("/oasys/${sixteenCharPk}/counter-sign")
+      .header(HttpHeaders.CONTENT_TYPE, "application/json")
+      .headers(setAuthorisation(roles = listOf("ROLE_STRENGTHS_AND_NEEDS_OASYS")))
+      .bodyValue(
+        OasysCounterSignRequest(
+          sanVersionNumber = -1,
+          sentencePlanVersionNumber = -1,
+          outcome = CounterSignOutcome.COUNTERSIGNED,
+          userDetails = OasysUserDetails(id = sixteenCharId, name = longName),
+        ),
+      )
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody()
+      .returnResult()
+
+    println(response)
+  }
+
+  @Test
+  fun `it returns 400 when validation errors occur in body only`() {
+    val sixteenCharId = "ABCDEFGHIJKLMNOP"
+    val longName = "SomebodyHasAReallyLongFirstName ItsAlmostAsLongAsTheirSurnameButNotQuite"
+
+    val response = webTestClient.post().uri("/oasys/012345678901234/counter-sign")
+      .header(HttpHeaders.CONTENT_TYPE, "application/json")
+      .headers(setAuthorisation(roles = listOf("ROLE_STRENGTHS_AND_NEEDS_OASYS")))
+      .bodyValue(
+        OasysCounterSignRequest(
+          sanVersionNumber = -1,
+          sentencePlanVersionNumber = -1,
+          outcome = CounterSignOutcome.COUNTERSIGNED,
+          userDetails = OasysUserDetails(id = sixteenCharId, name = longName),
+        ),
+      )
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody()
+      .returnResult()
+
+    println(response)
+  }
+
+  @Test
+  fun `it returns 400 when validation errors occur in parameter only`() {
+    val sixteenCharPk = "0123456789012345"
+
+    val response = webTestClient.post().uri("/oasys/${sixteenCharPk}/counter-sign")
+      .header(HttpHeaders.CONTENT_TYPE, "application/json")
+      .headers(setAuthorisation(roles = listOf("ROLE_STRENGTHS_AND_NEEDS_OASYS")))
+      .bodyValue(
+        OasysCounterSignRequest(
+          sanVersionNumber = 1,
+          sentencePlanVersionNumber = 1,
+          outcome = CounterSignOutcome.COUNTERSIGNED,
+          userDetails = OasysUserDetails(id = "1", name = "Test Name"),
+        ),
+      )
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody()
+      .returnResult()
+
+    println(response)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/CounterSignTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/CounterSignTest.kt
@@ -160,7 +160,7 @@ class CounterSignTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `it returns 400 when validation errors occur in both parameter and body`() {
+  fun `it returns 400 when validation errors occur in both the path parameter and body`() {
     val sixteenCharPk = "0123456789012345A"
     val sixteenCharId = "ABCDEFGHIJKLMNOP"
     val longName = "SomebodyHasAReallyLongFirstName ItsAlmostAsLongAsTheirSurnameButNotQuite"
@@ -182,11 +182,16 @@ class CounterSignTest : IntegrationTestBase() {
       .expectBody<ErrorResponse>()
       .returnResult()
 
-    assertThat(response.responseBody?.developerMessage).isEqualTo("")
+    assertThat(response.responseBody?.developerMessage).contains("oasysAssessmentPK - Must only contain numeric characters")
+    assertThat(response.responseBody?.developerMessage).contains("oasysAssessmentPK - size must be between 1 and 15")
+    assertThat(response.responseBody?.developerMessage).contains("sanVersionNumber - must be greater than or equal to 0")
+    assertThat(response.responseBody?.developerMessage).contains("sentencePlanVersionNumber - must be greater than or equal to 0")
+    assertThat(response.responseBody?.developerMessage).contains("userDetails.name - size must be between 0 and 64")
+    assertThat(response.responseBody?.developerMessage).contains("userDetails.id - size must be between 0 and 15")
   }
 
   @Test
-  fun `it returns 400 when validation errors occur in body only`() {
+  fun `it returns 400 when validation errors occur in the body only`() {
     val sixteenCharId = "ABCDEFGHIJKLMNOP"
     val longName = "SomebodyHasAReallyLongFirstName ItsAlmostAsLongAsTheirSurnameButNotQuite"
 
@@ -207,11 +212,14 @@ class CounterSignTest : IntegrationTestBase() {
       .expectBody<ErrorResponse>()
       .returnResult()
 
-    assertThat(response.responseBody?.developerMessage).isEqualTo("")
+    assertThat(response.responseBody?.developerMessage).contains("userDetails.id - size must be between 0 and 15")
+    assertThat(response.responseBody?.developerMessage).contains("userDetails.name - size must be between 0 and 64")
+    assertThat(response.responseBody?.developerMessage).contains("sentencePlanVersionNumber - must be greater than or equal to 0")
+    assertThat(response.responseBody?.developerMessage).contains("sanVersionNumber - must be greater than or equal to 0")
   }
 
   @Test
-  fun `it returns 400 when validation errors occur in parameter only`() {
+  fun `it returns 400 when validation errors occur in the path parameter only`() {
     val sixteenCharPk = "0123456789012345"
 
     val response = webTestClient.post().uri("/oasys/$sixteenCharPk/counter-sign")
@@ -231,7 +239,7 @@ class CounterSignTest : IntegrationTestBase() {
       .expectBody<ErrorResponse>()
       .returnResult()
 
-    assertThat(response.responseBody?.developerMessage).isEqualTo("")
+    assertThat(response.responseBody?.developerMessage).isEqualTo("[oasysAssessmentPK - size must be between 1 and 15]")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/CreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/CreateTest.kt
@@ -4,15 +4,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.expectBody
-import uk.gov.justice.digital.hmpps.arnscoordinatorapi.config.CounterSignOutcome
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.plan.entity.PlanType
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociation
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociationRepository
-import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.controller.request.OasysCounterSignRequest
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.controller.request.OasysCreateRequest
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDetails
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/CreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/CreateTest.kt
@@ -186,8 +186,6 @@ class CreateTest : IntegrationTestBase() {
       .expectBody<ErrorResponse>()
       .returnResult()
 
-    println(response)
-
     assertThat(response.responseBody?.developerMessage).contains("previousOasysAssessmentPk - Must only contain numeric characters")
     assertThat(response.responseBody?.developerMessage).contains("previousOasysAssessmentPk - size must be between 1 and 15")
     assertThat(response.responseBody?.developerMessage).contains("oasysAssessmentPk - Must only contain numeric characters")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/GetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/GetTest.kt
@@ -5,15 +5,11 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.expectBody
-import uk.gov.justice.digital.hmpps.arnscoordinatorapi.config.CounterSignOutcome
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociation
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociationRepository
-import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.controller.request.OasysCounterSignRequest
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.controller.response.OasysGetResponse
-import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDetails
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.util.UUID
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/LockTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/LockTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociation
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociationRepository
@@ -143,5 +144,27 @@ class LockTest : IntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isNotFound
+  }
+
+  @Test
+  fun `it returns 400 when validation errors occur in the path parameter`() {
+    val sixteenCharPk = "012345678901234A"
+
+    val response = webTestClient.post().uri("/oasys/$sixteenCharPk/lock")
+      .header(HttpHeaders.CONTENT_TYPE, "application/json")
+      .headers(setAuthorisation(roles = listOf("ROLE_STRENGTHS_AND_NEEDS_OASYS")))
+      .bodyValue(
+        OasysGenericRequest(
+          userDetails = OasysUserDetails(id = "1", name = "Test Name"),
+        ),
+      )
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody<ErrorResponse>()
+      .returnResult()
+
+    assertThat(response.responseBody?.developerMessage).contains("oasysAssessmentPK - Must only contain numeric characters")
+    assertThat(response.responseBody?.developerMessage).contains("oasysAssessmentPK - size must be between 1 and 15")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/MergeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/MergeTest.kt
@@ -29,10 +29,10 @@ class MergeTest : IntegrationTestBase() {
   fun `it successfully merges two pairs of OASys PKs`() {
     oasysAssociationRepository.saveAll(
       listOf(
-        OasysAssociation(id = 1L, oasysAssessmentPk = "OLD-1", entityType = EntityType.PLAN),
-        OasysAssociation(id = 2L, oasysAssessmentPk = "OLD-1", entityType = EntityType.ASSESSMENT),
-        OasysAssociation(id = 3L, oasysAssessmentPk = "OLD-2", entityType = EntityType.PLAN),
-        OasysAssociation(id = 4L, oasysAssessmentPk = "OLD-2", entityType = EntityType.ASSESSMENT),
+        OasysAssociation(id = 1L, oasysAssessmentPk = "101", entityType = EntityType.PLAN),
+        OasysAssociation(id = 2L, oasysAssessmentPk = "101", entityType = EntityType.ASSESSMENT),
+        OasysAssociation(id = 3L, oasysAssessmentPk = "102", entityType = EntityType.PLAN),
+        OasysAssociation(id = 4L, oasysAssessmentPk = "102", entityType = EntityType.ASSESSMENT),
       ),
     )
 
@@ -42,8 +42,8 @@ class MergeTest : IntegrationTestBase() {
       .bodyValue(
         OasysMergeRequest(
           merge = listOf(
-            OasysTransferAssociation(oldOasysAssessmentPK = "OLD-1", newOasysAssessmentPK = "NEW-1"),
-            OasysTransferAssociation(oldOasysAssessmentPK = "OLD-2", newOasysAssessmentPK = "NEW-2"),
+            OasysTransferAssociation(oldOasysAssessmentPK = "101", newOasysAssessmentPK = "201"),
+            OasysTransferAssociation(oldOasysAssessmentPK = "102", newOasysAssessmentPK = "202"),
           ),
           userDetails = OasysUserDetails(id = "1", name = "Test Name"),
         ),
@@ -56,20 +56,20 @@ class MergeTest : IntegrationTestBase() {
 
     assertThat(response?.message).isEqualTo("Successfully processed all 2 merge elements")
 
-    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("OLD-1")).isEmpty()
-    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("OLD-2")).isEmpty()
-    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("NEW-1").size).isEqualTo(2)
-    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("NEW-2").size).isEqualTo(2)
+    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("101")).isEmpty()
+    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("102")).isEmpty()
+    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("201").size).isEqualTo(2)
+    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("202").size).isEqualTo(2)
   }
 
   @Test
   fun `it returns a 409 when an association already exists for the new OASys PK`() {
     oasysAssociationRepository.saveAll(
       listOf(
-        OasysAssociation(id = 1L, oasysAssessmentPk = "OLD-3", entityType = EntityType.PLAN),
-        OasysAssociation(id = 2L, oasysAssessmentPk = "NEW-3", entityType = EntityType.PLAN),
-        OasysAssociation(id = 3L, oasysAssessmentPk = "OLD-4", entityType = EntityType.PLAN),
-        OasysAssociation(id = 4L, oasysAssessmentPk = "NEW-4", entityType = EntityType.PLAN),
+        OasysAssociation(id = 1L, oasysAssessmentPk = "103", entityType = EntityType.PLAN),
+        OasysAssociation(id = 2L, oasysAssessmentPk = "203", entityType = EntityType.PLAN),
+        OasysAssociation(id = 3L, oasysAssessmentPk = "104", entityType = EntityType.PLAN),
+        OasysAssociation(id = 4L, oasysAssessmentPk = "204", entityType = EntityType.PLAN),
       ),
     )
 
@@ -79,8 +79,8 @@ class MergeTest : IntegrationTestBase() {
       .bodyValue(
         OasysMergeRequest(
           merge = listOf(
-            OasysTransferAssociation(oldOasysAssessmentPK = "OLD-3", newOasysAssessmentPK = "NEW-3"),
-            OasysTransferAssociation(oldOasysAssessmentPK = "OLD-4", newOasysAssessmentPK = "NEW-4"),
+            OasysTransferAssociation(oldOasysAssessmentPK = "103", newOasysAssessmentPK = "203"),
+            OasysTransferAssociation(oldOasysAssessmentPK = "104", newOasysAssessmentPK = "204"),
           ),
           userDetails = OasysUserDetails(id = "1", name = "Test Name"),
         ),
@@ -91,19 +91,19 @@ class MergeTest : IntegrationTestBase() {
       .expectBody(ErrorResponse::class.java)
       .returnResult().responseBody
 
-    assertThat(response?.userMessage).isEqualTo("Existing association(s) for NEW-3, NEW-4")
+    assertThat(response?.userMessage).isEqualTo("Existing association(s) for 203, 204")
 
-    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("OLD-3").size).isEqualTo(1)
-    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("NEW-3").size).isEqualTo(1)
-    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("OLD-4").size).isEqualTo(1)
-    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("NEW-4").size).isEqualTo(1)
+    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("103").size).isEqualTo(1)
+    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("203").size).isEqualTo(1)
+    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("104").size).isEqualTo(1)
+    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("204").size).isEqualTo(1)
   }
 
   @Test
   fun `it returns a 404 when an association is not found`() {
     oasysAssociationRepository.saveAll(
       listOf(
-        OasysAssociation(id = 1L, oasysAssessmentPk = "OLD-5", entityType = EntityType.PLAN),
+        OasysAssociation(id = 1L, oasysAssessmentPk = "105", entityType = EntityType.PLAN),
       ),
     )
 
@@ -113,9 +113,9 @@ class MergeTest : IntegrationTestBase() {
       .bodyValue(
         OasysMergeRequest(
           merge = listOf(
-            OasysTransferAssociation(oldOasysAssessmentPK = "OLD-5", newOasysAssessmentPK = "NEW-5"),
-            OasysTransferAssociation(oldOasysAssessmentPK = "OLD-10", newOasysAssessmentPK = "NEW-10"),
-            OasysTransferAssociation(oldOasysAssessmentPK = "OLD-12", newOasysAssessmentPK = "NEW-12"),
+            OasysTransferAssociation(oldOasysAssessmentPK = "105", newOasysAssessmentPK = "205"),
+            OasysTransferAssociation(oldOasysAssessmentPK = "1010", newOasysAssessmentPK = "2010"),
+            OasysTransferAssociation(oldOasysAssessmentPK = "1012", newOasysAssessmentPK = "2012"),
           ),
           userDetails = OasysUserDetails(id = "1", name = "Test Name"),
         ),
@@ -126,14 +126,14 @@ class MergeTest : IntegrationTestBase() {
       .expectBody(ErrorResponse::class.java)
       .returnResult().responseBody
 
-    assertThat(response?.userMessage).isEqualTo("The following association(s) could not be located: OLD-10, OLD-12 and the operation has not been actioned.")
+    assertThat(response?.userMessage).isEqualTo("The following association(s) could not be located: 1010, 1012 and the operation has not been actioned.")
 
-    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("OLD-5").size).isEqualTo(1)
-    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("NEW-5")).isEmpty()
-    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("OLD-10")).isEmpty()
-    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("NEW-10")).isEmpty()
-    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("OLD-12")).isEmpty()
-    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("NEW-12")).isEmpty()
+    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("105").size).isEqualTo(1)
+    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("205")).isEmpty()
+    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("1010")).isEmpty()
+    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("2010")).isEmpty()
+    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("1012")).isEmpty()
+    assertThat(oasysAssociationRepository.findAllByOasysAssessmentPk("2012")).isEmpty()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/SignTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/SignTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.SignType
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociation
@@ -147,5 +148,28 @@ class SignTest : IntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isNotFound
+  }
+
+  @Test
+  fun `it returns 400 when validation errors occur in the path parameter`() {
+    val sixteenCharPk = "012345678901234A"
+
+    val response = webTestClient.post().uri("/oasys/$sixteenCharPk/sign")
+      .header(HttpHeaders.CONTENT_TYPE, "application/json")
+      .headers(setAuthorisation(roles = listOf("ROLE_STRENGTHS_AND_NEEDS_OASYS")))
+      .bodyValue(
+        OasysSignRequest(
+          signType = SignType.COUNTERSIGN,
+          userDetails = OasysUserDetails(id = "1", name = "Test Name"),
+        ),
+      )
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody<ErrorResponse>()
+      .returnResult()
+
+    assertThat(response.responseBody?.developerMessage).contains("oasysAssessmentPK - Must only contain numeric characters")
+    assertThat(response.responseBody?.developerMessage).contains("oasysAssessmentPK - size must be between 1 and 15")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/SoftDeleteTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/SoftDeleteTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociation
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociationRepository
@@ -253,5 +254,27 @@ class SoftDeleteTest : IntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isNotFound
+  }
+
+  @Test
+  fun `it returns 400 when validation errors occur in the path parameter`() {
+    val sixteenCharPk = "012345678901234A"
+
+    val response = webTestClient.post().uri("/oasys/$sixteenCharPk/soft-delete")
+      .header(HttpHeaders.CONTENT_TYPE, "application/json")
+      .headers(setAuthorisation(roles = listOf("ROLE_STRENGTHS_AND_NEEDS_OASYS")))
+      .bodyValue(
+        OasysGenericRequest(
+          userDetails = OasysUserDetails(id = "1", name = "Test Name"),
+        ),
+      )
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody<ErrorResponse>()
+      .returnResult()
+
+    assertThat(response.responseBody?.developerMessage).contains("oasysAssessmentPK - Must only contain numeric characters")
+    assertThat(response.responseBody?.developerMessage).contains("oasysAssessmentPK - size must be between 1 and 15")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/UndeleteTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/UndeleteTest.kt
@@ -6,12 +6,15 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.UndeleteData
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.UserDetails
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociation
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociationRepository
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.controller.request.OasysGenericRequest
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.controller.response.OasysGetResponse
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDetails
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.util.*
 
@@ -170,5 +173,27 @@ class UndeleteTest : IntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isNotFound
+  }
+
+  @Test
+  fun `it returns 400 when validation errors occur in the path parameter`() {
+    val sixteenCharPk = "012345678901234A"
+
+    val response = webTestClient.post().uri("/oasys/$sixteenCharPk/undelete")
+      .header(HttpHeaders.CONTENT_TYPE, "application/json")
+      .headers(setAuthorisation(roles = listOf("ROLE_STRENGTHS_AND_NEEDS_OASYS")))
+      .bodyValue(
+        OasysGenericRequest(
+          userDetails = OasysUserDetails(id = "1", name = "Test Name"),
+        ),
+      )
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody<ErrorResponse>()
+      .returnResult()
+
+    assertThat(response.responseBody?.developerMessage).contains("oasysAssessmentPK - Must only contain numeric characters")
+    assertThat(response.responseBody?.developerMessage).contains("oasysAssessmentPK - size must be between 1 and 15")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/common/entity/OasysTransferAssociationValidationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/common/entity/OasysTransferAssociationValidationTest.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity
+
+import jakarta.validation.ConstraintViolation
+import jakarta.validation.Validation
+import jakarta.validation.Validator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysTransferAssociation
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class OasysTransferAssociationValidationTest {
+
+  lateinit var validator: Validator
+
+  @BeforeAll
+  fun setUpBeforeAll() {
+    val factory = Validation.buildDefaultValidatorFactory()
+    validator = factory.validator
+  }
+
+  @Test
+  fun `Valid OasysTransferAssociation validation will have no violations`() {
+    val oasysTransferAssociation = OasysTransferAssociation(oldOasysAssessmentPK = "1", newOasysAssessmentPK = "2")
+
+    val violations: Set<ConstraintViolation<OasysTransferAssociation>> = validator.validate(oasysTransferAssociation)
+
+    assertThat(violations).hasSize(0)
+  }
+
+  @Test
+  fun `Invalid OasysTransferAssociation will produce size violations`() {
+    val invalidOasysAssessmentPK = "1234567890123456"
+    val oasysTransferAssociation = OasysTransferAssociation(invalidOasysAssessmentPK, invalidOasysAssessmentPK)
+
+    assertThat(validator.validate(oasysTransferAssociation)).hasSize(2)
+
+    assertThat(validator.validateProperty(oasysTransferAssociation, "oldOasysAssessmentPK").first().message).isEqualTo("size must be between 1 and 15")
+    assertThat(validator.validateProperty(oasysTransferAssociation, "newOasysAssessmentPK").first().message).isEqualTo("size must be between 1 and 15")
+  }
+
+  @Test
+  fun `Invalid OasysTransferAssociation will produce numeric only violations`() {
+    val invalidOasysAssessmentPK = "1A"
+    val oasysTransferAssociation = OasysTransferAssociation(invalidOasysAssessmentPK, invalidOasysAssessmentPK)
+
+    assertThat(validator.validate(oasysTransferAssociation)).hasSize(2)
+
+    assertThat(validator.validateProperty(oasysTransferAssociation, "oldOasysAssessmentPK").first().message).isEqualTo("Must only contain numeric characters")
+    assertThat(validator.validateProperty(oasysTransferAssociation, "newOasysAssessmentPK").first().message).isEqualTo("Must only contain numeric characters")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/common/entity/OasysUserDetailsValidationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/common/entity/OasysUserDetailsValidationTest.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity
+
+import jakarta.validation.ConstraintViolation
+import jakarta.validation.Validation
+import jakarta.validation.Validator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDetails
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class OasysUserDetailsValidationTest {
+
+  lateinit var validator: Validator
+
+  @BeforeAll
+  fun setUpBeforeAll() {
+    val factory = Validation.buildDefaultValidatorFactory()
+    validator = factory.validator
+  }
+
+  @Test
+  fun `Valid OasysUserDetails validation will have no violations`() {
+    val userName = "Test Name"
+    val fifteenCharId = "ABCDEFGHIJKLMNO"
+    val oasysUserDetails = OasysUserDetails(id = fifteenCharId, name = userName)
+
+    val violations: Set<ConstraintViolation<OasysUserDetails>> = validator.validate(oasysUserDetails)
+
+    assertThat(violations).hasSize(0)
+  }
+
+  @Test
+  fun `Invalid OasysUserDetails will produce size violations`() {
+    val userName = "SomebodyHasAReallyLongFirstName ItsAlmostAsLongAsTheirSurnameButNotQuite"
+    val sixteenCharId = "ABCDEFGHIJKLMNOP"
+    val oasysUserDetails = OasysUserDetails(id = sixteenCharId, name = userName)
+
+    assertThat(validator.validate(oasysUserDetails)).hasSize(2)
+
+    assertThat(validator.validateProperty(oasysUserDetails, "name").first().message).isEqualTo("size must be between 0 and 64")
+    assertThat(validator.validateProperty(oasysUserDetails, "id").first().message).isEqualTo("size must be between 0 and 15")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/entity/OasysTransferAssociationValidationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/entity/OasysTransferAssociationValidationTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity
 
 import jakarta.validation.ConstraintViolation
 import jakarta.validation.Validation
@@ -7,7 +7,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysTransferAssociation
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OasysTransferAssociationValidationTest {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/entity/OasysUserDetailsValidationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/entity/OasysUserDetailsValidationTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity
 
 import jakarta.validation.ConstraintViolation
 import jakarta.validation.Validation
@@ -7,7 +7,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.entity.OasysUserDetails
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OasysUserDetailsValidationTest {


### PR DESCRIPTION
Adding `use-site targets` to enable validation to occur on input data, as well as parsing for the exception when validation errors occur.