### PR TITLE
Added the Mod Platform egress IPs to Whitelist

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,9 +14,8 @@ generic-service:
     SP_API_BASE_URL: "https://sentence-plan-api-preprod.hmpps.service.justice.gov.uk"
   
   allowlist:
-    live_data-public-eu-west-2a: 13.41.38.176/32
-    live_data-public-eu-west-2b: 3.8.81.175/32
-    live_data-public-eu-west-2c: 3.11.197.133/32  
+    groups:
+      - mod-platform-live
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,6 +12,11 @@ generic-service:
     HMPPS_AUTH_BASE_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     SAN_API_BASE_URL: "https://api.strengths-based-needs-preprod.hmpps.service.justice.gov.uk"
     SP_API_BASE_URL: "https://sentence-plan-api-preprod.hmpps.service.justice.gov.uk"
+  
+  allowlist:
+    live_data-public-eu-west-2a: 13.41.38.176/32
+    live_data-public-eu-west-2b: 3.8.81.175/32
+    live_data-public-eu-west-2c: 3.11.197.133/32  
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
This commit adds the Mod Platform egress IPs to the NGINX Whitelist to enable API calls from OASys v7 to the Coordinator API.