### PR TITLE
Mod Platform - Specific Egress IPS

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,8 +14,10 @@ generic-service:
     SP_API_BASE_URL: "https://sentence-plan-api-preprod.hmpps.service.justice.gov.uk"
   
   allowlist:
-    groups:
-      - mod-platform-live
+    mod-platform-live-eu-west-2a-nat: 13.41.38.176/32
+    mod-platform-live-eu-west-2c-nat: 3.11.197.133/32
+    mod-platform-live-eu-west-2b-nat: 3.8.81.175/32
+    neil-tait-test-ip-remove-after-test: 51.155.102.238/32
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
This change swaps the mod-platform 'tag' for specific CIDR blocks to assist with debugging the preproduction deployment.  It also has a team member IP to assist with debug, which will be removed once we resolve deployment issues.