### PR TITLE
Add SoftDeleteCommand support for the AAP when `soft-delete`  is called

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/aap/api/AAPApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/aap/api/AAPApi.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.requ
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.request.command.CreateAssessmentCommand
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.request.command.IdentifierType
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.request.command.PropertyValue
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.request.command.SoftDeleteAssessmentCommand
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.request.command.Timeline
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.request.command.UpdateAssessmentPropertiesCommand
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.request.query.AssessmentVersionQuery
@@ -143,6 +144,39 @@ class AAPApi(
     )
   } catch (ex: Exception) {
     ApiOperationResult.Failure("Unexpected error during resetPlan: ${ex.message}", ex)
+  }
+
+  fun softDeleteAssessment(entityUuid: UUID, pointInTime: LocalDateTime, user: AAPUser): ApiOperationResult<Unit> = try {
+    val command = SoftDeleteAssessmentCommand(
+      assessmentUuid = entityUuid,
+      user = user,
+      pointInTime = pointInTime,
+    )
+
+    val request = CommandsRequest.of(command)
+
+    val response = aapApiWebClient.post()
+      .uri(apiProperties.endpoints.command)
+      .body(BodyInserters.fromValue(request))
+      .retrieve()
+      .bodyToMono(CommandsResponse::class.java)
+      .block()
+
+    val result = response?.commands?.firstOrNull()?.result
+      ?: throw IllegalStateException("No command result returned from AAP API")
+
+    if (!result.success) {
+      throw IllegalStateException("AAP API returned failure: ${result.message}")
+    }
+
+    ApiOperationResult.Success(Unit)
+  } catch (ex: WebClientResponseException) {
+    ApiOperationResult.Failure(
+      "HTTP error during soft-delete AAP assessment: Status code ${ex.statusCode}, Response body: ${ex.responseBodyAsString}",
+      ex,
+    )
+  } catch (ex: Exception) {
+    ApiOperationResult.Failure("Unexpected error during softDeleteAssessment: ${ex.message}", ex)
   }
 
   fun markMerged(assessmentUuid: UUID, user: AAPUser): ApiOperationResult<Unit> = try {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/aap/api/request/command/Command.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/aap/api/request/command/Command.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.requ
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes(
   JsonSubTypes.Type(value = CreateAssessmentCommand::class, name = "CreateAssessmentCommand"),
+  JsonSubTypes.Type(value = SoftDeleteAssessmentCommand::class, name = "SoftDeleteCommand"),
   JsonSubTypes.Type(value = UpdateAssessmentPropertiesCommand::class, name = "UpdateAssessmentPropertiesCommand"),
 )
 sealed interface Command {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/aap/api/request/command/SoftDeleteAssessmentCommand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/aap/api/request/command/SoftDeleteAssessmentCommand.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.request.command
+
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.request.AAPUser
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class SoftDeleteAssessmentCommand(
+  val assessmentUuid: UUID,
+  override val user: AAPUser,
+  val pointInTime: LocalDateTime,
+  val timeline: Timeline? = null,
+) : Command

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/strategy/AAPPlanStrategy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/strategy/AAPPlanStrategy.kt
@@ -40,6 +40,8 @@ import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.controller.request.
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.versioning.persistence.OasysEvent
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.versioning.persistence.OasysVersionEntity
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.versioning.service.OasysVersionService
+import java.time.Instant
+import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.UUID
 import kotlin.getOrElse
@@ -211,24 +213,38 @@ class AAPPlanStrategy(
     },
   )
 
-  override fun softDelete(softDeleteData: SoftDeleteData, entityUuid: UUID): OperationResult<VersionedEntity?> = runCatching {
-    val result =
-      oasysVersionService.softDeleteVersions(entityUuid, softDeleteData.versionFrom, softDeleteData.versionTo)
+  override fun softDelete(softDeleteData: SoftDeleteData, entityUuid: UUID): OperationResult<VersionedEntity?> {
+    if (softDeleteData.versionTo == null) {
+      val pointInTime = LocalDateTime.ofInstant(
+        Instant.ofEpochMilli(softDeleteData.versionFrom),
+        ZoneOffset.UTC,
+      )
+      val user = AAPUser(id = softDeleteData.userDetails.id, name = softDeleteData.userDetails.name)
 
-    Success(
-      VersionedEntity(
-        id = entityUuid,
-        version = result.version,
-        entityType = EntityType.AAP_PLAN,
-      ),
+      when (val softDeleteResult = aapApi.softDeleteAssessment(entityUuid, pointInTime, user)) {
+        is AAPApi.ApiOperationResult.Failure -> return Failure("Failed to soft-delete AAP assessment: ${softDeleteResult.errorMessage}")
+        is AAPApi.ApiOperationResult.Success -> {}
+      }
+    }
+
+    return runCatching {
+      val result = oasysVersionService.softDeleteVersions(entityUuid, softDeleteData.versionFrom, softDeleteData.versionTo)
+
+      Success(
+        VersionedEntity(
+          id = entityUuid,
+          version = result.version,
+          entityType = EntityType.AAP_PLAN,
+        ),
+      )
+    }.fold(
+      onSuccess = { it },
+      onFailure = { ex ->
+        log.error("Failed to soft-delete versions for entity $entityUuid", ex)
+        Failure("Something went wrong while deleting versions for entity $entityUuid")
+      },
     )
-  }.fold(
-    onSuccess = { it },
-    onFailure = { ex ->
-      log.error("Failed to soft-delete versions for entity $entityUuid", ex)
-      Failure("Something went wrong while deleting versions for entity $entityUuid")
-    },
-  )
+  }
 
   override fun undelete(undeleteData: UndeleteData, entityUuid: UUID): OperationResult<VersionedEntity> = runCatching {
     val result = oasysVersionService.undeleteVersions(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/IntegrationTestBase.kt
@@ -160,4 +160,8 @@ abstract class IntegrationTestBase {
   protected fun stubAAPMarkMerged(status: Int = 200) {
     aapApiMock.stubMarkMerged(status)
   }
+
+  protected fun stubAAPSoftDeleteAssessment(status: Int = 200) {
+    aapApiMock.stubSoftDeleteAssessment(status)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/SoftDeleteTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/SoftDeleteTest.kt
@@ -34,6 +34,7 @@ class SoftDeleteTest : IntegrationTestBase() {
   fun setUp() {
     stubGrantToken()
     stubAssessmentsSoftDelete()
+    stubAAPSoftDeleteAssessment()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/wiremock/AAPApiMock.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/wiremock/AAPApiMock.kt
@@ -130,6 +130,39 @@ class AAPApiMock : WireMockServer(8093) {
     )
   }
 
+  fun stubSoftDeleteAssessment(status: Int = 200) {
+    stubFor(
+      post("/command")
+        .withRequestBody(containing("SoftDeleteCommand"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+                {
+                  "commands": [
+                    {
+                      "request": {
+                        "type": "SoftDeleteCommand",
+                        "assessmentUuid": "00000000-0000-0000-0000-000000000000",
+                        "user": { "id": "1", "name": "Test Name" },
+                        "pointInTime": "2026-01-09T12:00:00"
+                      },
+                      "result": {
+                        "type": "CommandSuccessCommandResult",
+                        "message": "Done",
+                        "success": true
+                      }
+                    }
+                  ]
+                }
+              """.trimIndent(),
+            )
+            .withStatus(status),
+        ),
+    )
+  }
+
   fun stubQueryAssessmentVersions(status: Int = 200) {
     stubFor(
       post("/query").willReturn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/aap/api/AAPApiTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integrations/aap/api/AAPApiTest.kt
@@ -16,8 +16,10 @@ import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.request.AAPUser
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.request.AssessmentIdentifier
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.request.command.CreateAssessmentCommand
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.request.command.SoftDeleteAssessmentCommand
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.request.query.AssessmentVersionQuery
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.response.command.CommandResponse
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.response.command.CommandSuccessResult
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.response.command.CommandsResponse
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.response.command.CreateAssessmentCommandResult
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.aap.api.response.query.AssessmentVersionQueryResult
@@ -122,7 +124,6 @@ class AAPApiTest {
 
     @Test
     fun `should return success when AAP API deletes successfully`() {
-      // Arrange
       val assessmentUuid = UUID.randomUUID()
 
       `when`(webClient.delete()).thenReturn(requestHeadersUriSpec)
@@ -130,16 +131,13 @@ class AAPApiTest {
       `when`(requestHeadersSpec.retrieve()).thenReturn(responseSpec)
       `when`(responseSpec.bodyToMono(Void::class.java)).thenReturn(Mono.empty())
 
-      // Act
       val result = aapApi.deleteAssessment(assessmentUuid)
 
-      // Assert
       assertTrue(result is AAPApi.ApiOperationResult.Success)
     }
 
     @Test
     fun `should return failure when AAP API returns HTTP error`() {
-      // Arrange
       val assessmentUuid = UUID.randomUUID()
 
       `when`(webClient.delete()).thenReturn(requestHeadersUriSpec)
@@ -148,10 +146,8 @@ class AAPApiTest {
       `when`(responseSpec.bodyToMono(Void::class.java))
         .thenReturn(Mono.error(WebClientResponseException.create(HttpStatus.NOT_FOUND.value(), "Not Found", HttpHeaders.EMPTY, "Error body".toByteArray(), null)))
 
-      // Act
       val result = aapApi.deleteAssessment(assessmentUuid)
 
-      // Assert
       assertTrue(result is AAPApi.ApiOperationResult.Failure)
       val failureResult = result as AAPApi.ApiOperationResult.Failure
       assertTrue(failureResult.errorMessage.contains("HTTP error during delete AAP assessment"))
@@ -159,7 +155,6 @@ class AAPApiTest {
 
     @Test
     fun `should return failure when unexpected exception occurs`() {
-      // Arrange
       val assessmentUuid = UUID.randomUUID()
 
       `when`(webClient.delete()).thenReturn(requestHeadersUriSpec)
@@ -168,10 +163,8 @@ class AAPApiTest {
       `when`(responseSpec.bodyToMono(Void::class.java))
         .thenReturn(Mono.error(RuntimeException("Unexpected error")))
 
-      // Act
       val result = aapApi.deleteAssessment(assessmentUuid)
 
-      // Assert
       assertTrue(result is AAPApi.ApiOperationResult.Failure)
       val failureResult = result as AAPApi.ApiOperationResult.Failure
       assertTrue(failureResult.errorMessage.contains("Unexpected error during deleteAssessment"))
@@ -183,7 +176,6 @@ class AAPApiTest {
 
     @Test
     fun `should return success when AAP API returns a valid response`() {
-      // Arrange
       val assessmentUuid = UUID.randomUUID()
       val aggregateUuid = UUID.randomUUID()
       val now = LocalDateTime.now()
@@ -219,10 +211,8 @@ class AAPApiTest {
       `when`(requestHeadersSpec.retrieve()).thenReturn(responseSpec)
       `when`(responseSpec.bodyToMono(QueriesResponse::class.java)).thenReturn(Mono.just(response))
 
-      // Act
       val result = aapApi.fetchAssessment(assessmentUuid, now)
 
-      // Assert
       assertTrue(result is AAPApi.ApiOperationResult.Success)
       val successResult = result as AAPApi.ApiOperationResult.Success
       assertEquals(assessmentUuid, successResult.data.assessmentUuid)
@@ -232,7 +222,6 @@ class AAPApiTest {
 
     @Test
     fun `should return failure when AAP API returns HTTP error`() {
-      // Arrange
       val entityUuid = UUID.randomUUID()
       val timestamp = LocalDateTime.now()
 
@@ -243,10 +232,8 @@ class AAPApiTest {
       `when`(responseSpec.bodyToMono(QueriesResponse::class.java))
         .thenReturn(Mono.error(WebClientResponseException.create(HttpStatus.NOT_FOUND.value(), "Not Found", HttpHeaders.EMPTY, "Error body".toByteArray(), null)))
 
-      // Act
       val result = aapApi.fetchAssessment(entityUuid, timestamp)
 
-      // Assert
       assertTrue(result is AAPApi.ApiOperationResult.Failure)
       val failureResult = result as AAPApi.ApiOperationResult.Failure
       assertTrue(failureResult.errorMessage.contains("HTTP error during fetch AAP assessment"))
@@ -254,7 +241,6 @@ class AAPApiTest {
 
     @Test
     fun `should return failure when AAP API returns empty queries list`() {
-      // Arrange
       val entityUuid = UUID.randomUUID()
       val timestamp = LocalDateTime.now()
       val response = QueriesResponse(queries = emptyList())
@@ -265,10 +251,8 @@ class AAPApiTest {
       `when`(requestHeadersSpec.retrieve()).thenReturn(responseSpec)
       `when`(responseSpec.bodyToMono(QueriesResponse::class.java)).thenReturn(Mono.just(response))
 
-      // Act
       val result = aapApi.fetchAssessment(entityUuid, timestamp)
 
-      // Assert
       assertTrue(result is AAPApi.ApiOperationResult.Failure)
       val failureResult = result as AAPApi.ApiOperationResult.Failure
       assertTrue(failureResult.errorMessage.contains("No query result returned from AAP API"))
@@ -276,7 +260,6 @@ class AAPApiTest {
 
     @Test
     fun `should return failure when unexpected exception occurs`() {
-      // Arrange
       val entityUuid = UUID.randomUUID()
       val timestamp = LocalDateTime.now()
 
@@ -287,13 +270,78 @@ class AAPApiTest {
       `when`(responseSpec.bodyToMono(QueriesResponse::class.java))
         .thenReturn(Mono.error(RuntimeException("Unexpected error")))
 
-      // Act
       val result = aapApi.fetchAssessment(entityUuid, timestamp)
 
-      // Assert
       assertTrue(result is AAPApi.ApiOperationResult.Failure)
       val failureResult = result as AAPApi.ApiOperationResult.Failure
       assertTrue(failureResult.errorMessage.contains("Unexpected error during fetchAssessment"))
+    }
+  }
+
+  @Nested
+  inner class SoftDeleteAssessment {
+
+    @Test
+    fun `should return success when AAP API returns a valid response`() {
+      val entityUuid = UUID.randomUUID()
+      val pointInTime = LocalDateTime.parse("2026-01-09T12:00:00")
+      val user = AAPUser(id = "user-id", name = "User Name")
+
+      val response = CommandsResponse(
+        commands = listOf(
+          CommandResponse(mock<SoftDeleteAssessmentCommand>(), result = CommandSuccessResult()),
+        ),
+      )
+
+      `when`(webClient.post()).thenReturn(requestBodyUriSpec)
+      `when`(requestBodyUriSpec.uri("/command")).thenReturn(requestBodySpec)
+      `when`(requestBodySpec.body(any())).thenReturn(requestHeadersSpec)
+      `when`(requestHeadersSpec.retrieve()).thenReturn(responseSpec)
+      `when`(responseSpec.bodyToMono(CommandsResponse::class.java)).thenReturn(Mono.just(response))
+
+      val result = aapApi.softDeleteAssessment(entityUuid, pointInTime, user)
+
+      assertTrue(result is AAPApi.ApiOperationResult.Success)
+    }
+
+    @Test
+    fun `should return failure when AAP API returns HTTP error`() {
+      val entityUuid = UUID.randomUUID()
+      val pointInTime = LocalDateTime.parse("2026-01-09T12:00:00")
+      val user = AAPUser(id = "user-id", name = "User Name")
+
+      `when`(webClient.post()).thenReturn(requestBodyUriSpec)
+      `when`(requestBodyUriSpec.uri("/command")).thenReturn(requestBodySpec)
+      `when`(requestBodySpec.body(any())).thenReturn(requestHeadersSpec)
+      `when`(requestHeadersSpec.retrieve()).thenReturn(responseSpec)
+      `when`(responseSpec.bodyToMono(CommandsResponse::class.java))
+        .thenReturn(Mono.error(WebClientResponseException.create(HttpStatus.BAD_REQUEST.value(), "Bad Request", HttpHeaders.EMPTY, "Error body".toByteArray(), null)))
+
+      val result = aapApi.softDeleteAssessment(entityUuid, pointInTime, user)
+
+      assertTrue(result is AAPApi.ApiOperationResult.Failure)
+      val failureResult = result as AAPApi.ApiOperationResult.Failure
+      assertTrue(failureResult.errorMessage.contains("HTTP error during soft-delete AAP assessment"))
+    }
+
+    @Test
+    fun `should return failure when unexpected exception occurs`() {
+      val entityUuid = UUID.randomUUID()
+      val pointInTime = LocalDateTime.parse("2026-01-09T12:00:00")
+      val user = AAPUser(id = "user-id", name = "User Name")
+
+      `when`(webClient.post()).thenReturn(requestBodyUriSpec)
+      `when`(requestBodyUriSpec.uri("/command")).thenReturn(requestBodySpec)
+      `when`(requestBodySpec.body(any())).thenReturn(requestHeadersSpec)
+      `when`(requestHeadersSpec.retrieve()).thenReturn(responseSpec)
+      `when`(responseSpec.bodyToMono(CommandsResponse::class.java))
+        .thenReturn(Mono.error(RuntimeException("Unexpected error")))
+
+      val result = aapApi.softDeleteAssessment(entityUuid, pointInTime, user)
+
+      assertTrue(result is AAPApi.ApiOperationResult.Failure)
+      val failureResult = result as AAPApi.ApiOperationResult.Failure
+      assertTrue(failureResult.errorMessage.contains("Unexpected error during softDeleteAssessment"))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/strategy/AAPPlanStrategyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/strategy/AAPPlanStrategyTest.kt
@@ -958,46 +958,120 @@ class AAPPlanStrategyTest {
 
   @Nested
   inner class SoftDelete {
-    val softDeleteData = SoftDeleteData(
-      UserDetails("id", "name", UserType.OASYS),
-      versionFrom = 1,
-      versionTo = 2,
-    )
     val versionedEntity = OasysVersionEntity(
       createdBy = OasysEvent.LOCKED,
       entityUuid = UUID.randomUUID(),
       version = 2,
     )
 
-    @Test
-    fun `should return success when soft-delete is successful`() {
-      whenever(oasysVersionService.softDeleteVersions(versionedEntity.entityUuid, 1, 2)).thenReturn(
-        versionedEntity,
+    val expectedUser = AAPUser(id = "id", name = "name")
+
+    @Nested
+    inner class WithoutVersionTo {
+      val softDeleteData = SoftDeleteData(
+        UserDetails("id", "name", UserType.OASYS),
+        versionFrom = 1,
       )
 
-      val result = planStrategy.softDelete(softDeleteData, versionedEntity.entityUuid)
+      val expectedPointInTime = LocalDateTime.ofInstant(
+        java.time.Instant.ofEpochMilli(softDeleteData.versionFrom),
+        ZoneOffset.UTC,
+      )
 
-      assertTrue(result is OperationResult.Success)
-      (result as OperationResult.Success).data?.let {
-        assertEquals(it.id, versionedEntity.entityUuid)
-        assertEquals(it.version, versionedEntity.version)
+      @Test
+      fun `should call AAP soft-delete and return success`() {
+        whenever(aapApi.softDeleteAssessment(versionedEntity.entityUuid, expectedPointInTime, expectedUser))
+          .thenReturn(AAPApi.ApiOperationResult.Success(Unit))
+        whenever(oasysVersionService.softDeleteVersions(versionedEntity.entityUuid, 1, null)).thenReturn(
+          versionedEntity,
+        )
+
+        val result = planStrategy.softDelete(softDeleteData, versionedEntity.entityUuid)
+
+        assertTrue(result is OperationResult.Success)
+        (result as OperationResult.Success).data?.let {
+          assertEquals(it.id, versionedEntity.entityUuid)
+          assertEquals(it.version, versionedEntity.version)
+        }
+        verify(aapApi).softDeleteAssessment(versionedEntity.entityUuid, expectedPointInTime, expectedUser)
+        verify(oasysVersionService).softDeleteVersions(versionedEntity.entityUuid, 1, null)
       }
-      verify(oasysVersionService).softDeleteVersions(versionedEntity.entityUuid, 1, 2)
+
+      @Test
+      fun `should return failure when AAP soft-delete fails`() {
+        whenever(aapApi.softDeleteAssessment(versionedEntity.entityUuid, expectedPointInTime, expectedUser))
+          .thenReturn(AAPApi.ApiOperationResult.Failure("Soft-delete failed"))
+
+        val result = planStrategy.softDelete(softDeleteData, versionedEntity.entityUuid)
+
+        assertTrue(result is OperationResult.Failure)
+        assertEquals(
+          "Failed to soft-delete AAP assessment: Soft-delete failed",
+          (result as OperationResult.Failure).errorMessage,
+        )
+        verify(aapApi).softDeleteAssessment(versionedEntity.entityUuid, expectedPointInTime, expectedUser)
+        verify(oasysVersionService, org.mockito.Mockito.never()).softDeleteVersions(any(), any(), any())
+      }
+
+      @Test
+      fun `should return failure when local soft-delete fails`() {
+        whenever(aapApi.softDeleteAssessment(versionedEntity.entityUuid, expectedPointInTime, expectedUser))
+          .thenReturn(AAPApi.ApiOperationResult.Success(Unit))
+        whenever(oasysVersionService.softDeleteVersions(versionedEntity.entityUuid, 1, null))
+          .thenThrow(RuntimeException("Error occurred"))
+
+        val result = planStrategy.softDelete(softDeleteData, versionedEntity.entityUuid)
+
+        assertTrue(result is OperationResult.Failure)
+        assertEquals(
+          "Something went wrong while deleting versions for entity ${versionedEntity.entityUuid}",
+          (result as OperationResult.Failure).errorMessage,
+        )
+        verify(aapApi).softDeleteAssessment(versionedEntity.entityUuid, expectedPointInTime, expectedUser)
+        verify(oasysVersionService).softDeleteVersions(versionedEntity.entityUuid, 1, null)
+      }
     }
 
-    @Test
-    fun `should return failure when soft-delete fails`() {
-      whenever(oasysVersionService.softDeleteVersions(versionedEntity.entityUuid, 1, 2))
-        .thenThrow(RuntimeException("Error occurred"))
-
-      val result = planStrategy.softDelete(softDeleteData, versionedEntity.entityUuid)
-
-      assertTrue(result is OperationResult.Failure)
-      assertEquals(
-        result,
-        OperationResult.Failure<VersionedEntity?>("Something went wrong while deleting versions for entity ${versionedEntity.entityUuid}"),
+    @Nested
+    inner class WithVersionTo {
+      val softDeleteData = SoftDeleteData(
+        UserDetails("id", "name", UserType.OASYS),
+        versionFrom = 1,
+        versionTo = 2,
       )
-      verify(oasysVersionService).softDeleteVersions(versionedEntity.entityUuid, 1, 2)
+
+      @Test
+      fun `should not call AAP soft-delete and only delete local versions`() {
+        whenever(oasysVersionService.softDeleteVersions(versionedEntity.entityUuid, 1, 2)).thenReturn(
+          versionedEntity,
+        )
+
+        val result = planStrategy.softDelete(softDeleteData, versionedEntity.entityUuid)
+
+        assertTrue(result is OperationResult.Success)
+        (result as OperationResult.Success).data?.let {
+          assertEquals(it.id, versionedEntity.entityUuid)
+          assertEquals(it.version, versionedEntity.version)
+        }
+        verify(aapApi, org.mockito.Mockito.never()).softDeleteAssessment(any(), any(), any())
+        verify(oasysVersionService).softDeleteVersions(versionedEntity.entityUuid, 1, 2)
+      }
+
+      @Test
+      fun `should return failure when local soft-delete fails`() {
+        whenever(oasysVersionService.softDeleteVersions(versionedEntity.entityUuid, 1, 2))
+          .thenThrow(RuntimeException("Error occurred"))
+
+        val result = planStrategy.softDelete(softDeleteData, versionedEntity.entityUuid)
+
+        assertTrue(result is OperationResult.Failure)
+        assertEquals(
+          "Something went wrong while deleting versions for entity ${versionedEntity.entityUuid}",
+          (result as OperationResult.Failure).errorMessage,
+        )
+        verify(aapApi, org.mockito.Mockito.never()).softDeleteAssessment(any(), any(), any())
+        verify(oasysVersionService).softDeleteVersions(versionedEntity.entityUuid, 1, 2)
+      }
     }
   }
 


### PR DESCRIPTION
- Use new `SoftDeleteAssessmentCommand` to soft delete events in an AAP assessment when `soft-delete` endpoint is called
- When `versionTo` is `null` (delete from a point forward): call AAP-API soft delete, then deletes local OASys versions
- When `versionTo` is set (range delete), skip the AAP API call entirely and only deletes local OASys version records. No AAP call here because deleting a range of events doesnt work in an event-sourced system