### PR TITLE
ARN-3119: Updated endpoint to return only latest oasyspk

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/controller/EntityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/controller/EntityController.kt
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.controller.response.EntityAssociationDetails
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.controller.response.VersionsResponse
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.OasysCoordinatorService
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.OasysAssociationsService
@@ -35,11 +36,11 @@ class EntityController(
   private val oasysAssociationsService: OasysAssociationsService,
 ) {
   @RequestMapping(path = ["/associations"], method = [RequestMethod.POST])
-  @Operation(description = "Return OASys Assessment PKs for the given entity UUIDs")
+  @Operation(description = "Return current OASys association details (PK, region, version) for the given entity UUIDs")
   @PreAuthorize("hasAnyRole('ROLE_STRENGTHS_AND_NEEDS_OASYS','ROLE_SENTENCE_PLAN_READ')")
   @ApiResponses(
     value = [
-      ApiResponse(responseCode = "200", description = "OASys PKs returned"),
+      ApiResponse(responseCode = "200", description = "Association details returned"),
       ApiResponse(
         responseCode = "401",
         description = "Unauthorised",
@@ -54,7 +55,7 @@ class EntityController(
   )
   fun associationsByEntityUuids(
     @RequestBody entityUuids: List<UUID>,
-  ): Map<UUID, List<String>> = oasysAssociationsService.findOasysPksByEntityIds(entityUuids)
+  ): Map<UUID, EntityAssociationDetails> = oasysAssociationsService.findLatestAssociationDetailsByEntityIds(entityUuids)
 
   @RequestMapping(path = ["/versions/{entityUuid}"], method = [RequestMethod.GET])
   @Operation(description = "Gets the list of both assessment AND sentence plan versions for a given entity ID")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/controller/response/EntityAssociationDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/controller/response/EntityAssociationDetails.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.arnscoordinatorapi.controller.response
+
+data class EntityAssociationDetails(
+  val oasysAssessmentPk: String,
+  val regionPrisonCode: String?,
+  val baseVersion: Long,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/associations/OasysAssociationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/associations/OasysAssociationsService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.controller.response.EntityAssociationDetails
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.OperationResult
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociation
@@ -24,10 +25,19 @@ class OasysAssociationsService(
 
   fun findOasysPkByEntityId(entityUuid: UUID): String? = oasysAssociationRepository.findAllByEntityUuid(entityUuid).maxByOrNull { it.createdAt }?.oasysAssessmentPk
 
-  fun findOasysPksByEntityIds(entityUuids: Collection<UUID>): Map<UUID, List<String>> = oasysAssociationRepository
+  fun findLatestAssociationDetailsByEntityIds(entityUuids: Collection<UUID>): Map<UUID, EntityAssociationDetails> = oasysAssociationRepository
     .findAllByEntityUuidIn(entityUuids)
     .groupBy { it.entityUuid }
-    .mapValues { (_, associations) -> associations.mapNotNull { it.oasysAssessmentPk } }
+    .mapNotNull { (entityUuid, associations) ->
+      val latest = associations.maxByOrNull { it.createdAt } ?: return@mapNotNull null
+      val pk = latest.oasysAssessmentPk ?: return@mapNotNull null
+      entityUuid to EntityAssociationDetails(
+        oasysAssessmentPk = pk,
+        regionPrisonCode = latest.regionPrisonCode,
+        baseVersion = latest.baseVersion,
+      )
+    }
+    .toMap()
 
   fun findAllIncludingDeleted(entityUuid: UUID): List<OasysAssociation> = oasysAssociationRepository.findAllByEntityUuidIncludingDeleted(entityUuid)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/EntityAssociationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/EntityAssociationsTest.kt
@@ -71,17 +71,20 @@ class EntityAssociationsTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `returns OASys PKs for multiple entity UUIDs`() {
+    fun `returns latest association details per entity UUID`() {
       val entityUuid1 = UUID.randomUUID()
       val entityUuid2 = UUID.randomUUID()
       val entityUuid3 = UUID.randomUUID()
 
+      // entityUuid1 has two associations; the second (PK 101) is the latest
       oasysAssociationRepository.saveAll(
         listOf(
-          OasysAssociation(entityUuid = entityUuid1, entityType = EntityType.AAP_PLAN, oasysAssessmentPk = "100"),
-          OasysAssociation(entityUuid = entityUuid1, entityType = EntityType.AAP_PLAN, oasysAssessmentPk = "101"),
-          OasysAssociation(entityUuid = entityUuid2, entityType = EntityType.AAP_PLAN, oasysAssessmentPk = "200"),
+          OasysAssociation(entityUuid = entityUuid1, entityType = EntityType.AAP_PLAN, oasysAssessmentPk = "100", regionPrisonCode = "LDN", baseVersion = 1),
+          OasysAssociation(entityUuid = entityUuid2, entityType = EntityType.AAP_PLAN, oasysAssessmentPk = "200", regionPrisonCode = "MAN", baseVersion = 5),
         ),
+      )
+      oasysAssociationRepository.save(
+        OasysAssociation(entityUuid = entityUuid1, entityType = EntityType.AAP_PLAN, oasysAssessmentPk = "101", regionPrisonCode = "LDN", baseVersion = 2),
       )
 
       webTestClient.post()
@@ -94,8 +97,8 @@ class EntityAssociationsTest : IntegrationTestBase() {
         .expectBody().json(
           """
           {
-            "$entityUuid1": ["100", "101"],
-            "$entityUuid2": ["200"]
+            "$entityUuid1": { "oasysAssessmentPk": "101", "regionPrisonCode": "LDN", "baseVersion": 2 },
+            "$entityUuid2": { "oasysAssessmentPk": "200", "regionPrisonCode": "MAN", "baseVersion": 5 }
           }
           """,
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/associations/OasysAssociationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/associations/OasysAssociationsServiceTest.kt
@@ -194,32 +194,40 @@ class OasysAssociationsServiceTest {
   }
 
   @Nested
-  inner class FindOasysPksByEntityUuids {
+  inner class FindLatestAssociationDetailsByEntityIds {
     @Test
     fun `should return empty map when no associations are found`() {
       val entityUuids = listOf(UUID.randomUUID())
       `when`(oasysAssociationRepository.findAllByEntityUuidIn(entityUuids)).thenReturn(emptyList())
 
-      val result = oasysAssociationsService.findOasysPksByEntityIds(entityUuids)
+      val result = oasysAssociationsService.findLatestAssociationDetailsByEntityIds(entityUuids)
 
       assertTrue(result.isEmpty())
       verify(oasysAssociationRepository).findAllByEntityUuidIn(entityUuids)
     }
 
     @Test
-    fun `should group OASys PKs by entity UUID`() {
+    fun `should return latest association details per entity UUID`() {
       val entityUuid1 = UUID.randomUUID()
       val entityUuid2 = UUID.randomUUID()
+      val older = java.time.LocalDateTime.now().minusDays(2)
+      val newer = java.time.LocalDateTime.now()
       val associations = listOf(
-        OasysAssociation(id = 1L, entityUuid = entityUuid1, entityType = EntityType.AAP_PLAN, oasysAssessmentPk = "100"),
-        OasysAssociation(id = 2L, entityUuid = entityUuid1, entityType = EntityType.AAP_PLAN, oasysAssessmentPk = "101"),
-        OasysAssociation(id = 3L, entityUuid = entityUuid2, entityType = EntityType.AAP_PLAN, oasysAssessmentPk = "200"),
+        OasysAssociation(id = 1L, entityUuid = entityUuid1, entityType = EntityType.AAP_PLAN, oasysAssessmentPk = "100", regionPrisonCode = "LDN", baseVersion = 1, createdAt = older),
+        OasysAssociation(id = 2L, entityUuid = entityUuid1, entityType = EntityType.AAP_PLAN, oasysAssessmentPk = "101", regionPrisonCode = "LDN", baseVersion = 2, createdAt = newer),
+        OasysAssociation(id = 3L, entityUuid = entityUuid2, entityType = EntityType.AAP_PLAN, oasysAssessmentPk = "200", regionPrisonCode = "MAN", baseVersion = 5, createdAt = newer),
       )
       `when`(oasysAssociationRepository.findAllByEntityUuidIn(listOf(entityUuid1, entityUuid2))).thenReturn(associations)
 
-      val result = oasysAssociationsService.findOasysPksByEntityIds(listOf(entityUuid1, entityUuid2))
+      val result = oasysAssociationsService.findLatestAssociationDetailsByEntityIds(listOf(entityUuid1, entityUuid2))
 
-      assertEquals(mapOf(entityUuid1 to listOf("100", "101"), entityUuid2 to listOf("200")), result)
+      assertEquals(
+        mapOf(
+          entityUuid1 to uk.gov.justice.digital.hmpps.arnscoordinatorapi.controller.response.EntityAssociationDetails("101", "LDN", 2),
+          entityUuid2 to uk.gov.justice.digital.hmpps.arnscoordinatorapi.controller.response.EntityAssociationDetails("200", "MAN", 5),
+        ),
+        result,
+      )
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/associations/OasysAssociationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/associations/OasysAssociationsServiceTest.kt
@@ -10,6 +10,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import uk.gov.justice.digital.hmpps.arnscoordinatorapi.controller.response.EntityAssociationDetails
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.integrations.common.entity.OperationResult
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.EntityType
 import uk.gov.justice.digital.hmpps.arnscoordinatorapi.oasys.associations.repository.OasysAssociation
@@ -223,8 +224,8 @@ class OasysAssociationsServiceTest {
 
       assertEquals(
         mapOf(
-          entityUuid1 to uk.gov.justice.digital.hmpps.arnscoordinatorapi.controller.response.EntityAssociationDetails("101", "LDN", 2),
-          entityUuid2 to uk.gov.justice.digital.hmpps.arnscoordinatorapi.controller.response.EntityAssociationDetails("200", "MAN", 5),
+          entityUuid1 to EntityAssociationDetails("101", "LDN", 2),
+          entityUuid2 to EntityAssociationDetails("200", "MAN", 5),
         ),
         result,
       )


### PR DESCRIPTION
Endpoint that view-api calls only requires the latest PK and now needs additional information on associated entities including region code and version.