### PR TITLE
Fix soft delete and undelete version ranges

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/versioning/persistence/OasysVersionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/versioning/persistence/OasysVersionRepository.kt
@@ -22,11 +22,11 @@ interface OasysVersionRepository : JpaRepository<OasysVersionEntity, Long> {
     SELECT *
     FROM coordinator.oasys_version
     WHERE entity_uuid = :entityUuid
-    AND version BETWEEN :fromVersion AND :toVersion
+    AND version >= :fromVersion AND version < :toVersion
     AND deleted = true
   """,
     nativeQuery = true,
   )
   fun findAllDeletedByEntityUuidAndVersionBetween(entityUuid: UUID, fromVersion: Long, toVersion: Long): List<OasysVersionEntity>
-  fun findAllByEntityUuidAndVersionBetween(entityUuid: UUID, fromVersion: Long, toVersion: Long): List<OasysVersionEntity>
+  fun findAllByEntityUuidAndVersionGreaterThanEqualAndVersionLessThan(entityUuid: UUID, fromVersion: Long, toVersion: Long): List<OasysVersionEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/versioning/service/OasysVersionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/versioning/service/OasysVersionService.kt
@@ -30,7 +30,7 @@ class OasysVersionService(
 
   fun softDeleteVersions(entityUuid: UUID, from: Long, to: Long?): OasysVersionEntity {
     val toVersion = to ?: getLatestVersionNumber()
-    val versions = repository.findAllByEntityUuidAndVersionBetween(entityUuid, from, toVersion)
+    val versions = repository.findAllByEntityUuidAndVersionGreaterThanEqualAndVersionLessThan(entityUuid, from, toVersion)
 
     if (versions.isEmpty()) {
       val errorMessage = "No versions found for entity $entityUuid between $from to $toVersion"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/SoftDeleteTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/integration/SoftDeleteTest.kt
@@ -102,7 +102,7 @@ class SoftDeleteTest : IntegrationTestBase() {
       .returnResult()
       .responseBody
 
-    val deletedPlanVersions = oasysVersionRepository.findAllDeletedByEntityUuidAndVersionBetween(planUuid, 2, 2)
+    val deletedPlanVersions = oasysVersionRepository.findAllDeletedByEntityUuidAndVersionBetween(planUuid, 2, 3)
     val activePlanVersions = oasysVersionRepository.findAllByEntityUuid(planUuid)
 
     assertThat(response?.sanAssessmentId).isEqualTo(assessmentUuid)
@@ -185,7 +185,7 @@ class SoftDeleteTest : IntegrationTestBase() {
       .returnResult()
       .responseBody
 
-    val deletedPlanVersions = oasysVersionRepository.findAllDeletedByEntityUuidAndVersionBetween(planUuid, 0, 0)
+    val deletedPlanVersions = oasysVersionRepository.findAllDeletedByEntityUuidAndVersionBetween(planUuid, 0, 1)
 
     assertThat(response!!.sanAssessmentId).isEqualTo(UUID(0, 0))
     assertThat(response.sanAssessmentVersion).isEqualTo(0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/versioning/service/OasysVersionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/versioning/service/OasysVersionServiceTest.kt
@@ -149,7 +149,7 @@ class OasysVersionServiceTest {
       whenever(repository.findAllByEntityUuidAndVersionGreaterThanEqualAndVersionLessThan(uuid, 1767956400000L, 1767960000000L)).thenReturn(emptyList())
 
       val ex = assertThrows<Error> {
-        service.softDeleteVersions(uuid, from = 1767956400000L, to = 1767960000001L)
+        service.softDeleteVersions(uuid, from = 1767956400000L, to = 1767960000000L)
       }
 
       assertTrue(ex.message!!.contains("No versions found for entity $uuid between 1767956400000 to 1767960000000"))
@@ -189,7 +189,7 @@ class OasysVersionServiceTest {
         listOf(entity(uuid, 1767952800000, deleted = true), entity(uuid, 1767956400000L, deleted = true), entity(uuid, 1767960000000L, deleted = true))
       whenever(repository.saveAll(anyList())).thenReturn(savedList)
 
-      val last = service.softDeleteVersions(uuid, 1767952800000, 1767960000001L)
+      val last = service.softDeleteVersions(uuid, 1767952800000, 1767960000000L)
 
       assertEquals(1767960000000L, last.version)
       assertTrue(last.deleted)
@@ -205,7 +205,7 @@ class OasysVersionServiceTest {
       whenever(repository.findAllDeletedByEntityUuidAndVersionBetween(uuid, 1767952800000, 1767956400000L)).thenReturn(emptyList())
 
       assertThrows<Error> {
-        service.undeleteVersions(uuid, 1767952800000, 1767956400001L)
+        service.undeleteVersions(uuid, 1767952800000, 1767956400000L)
       }
 
       verify(repository).findAllDeletedByEntityUuidAndVersionBetween(uuid, 1767952800000, 1767956400000L)
@@ -243,7 +243,7 @@ class OasysVersionServiceTest {
       val savedList = listOf(entity(uuid, 1767952800000, deleted = false), entity(uuid, 1767956400000L, deleted = false))
       whenever(repository.saveAll(anyList())).thenReturn(savedList)
 
-      val last = service.undeleteVersions(uuid, 1767952800000, 1767956400001L)
+      val last = service.undeleteVersions(uuid, 1767952800000, 1767956400000L)
 
       assertEquals(1767956400000L, last.version)
       assertFalse(last.deleted)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/versioning/service/OasysVersionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnscoordinatorapi/oasys/versioning/service/OasysVersionServiceTest.kt
@@ -146,14 +146,14 @@ class OasysVersionServiceTest {
     fun `it throws when no versions are found in the provided range`() {
       val uuid = UUID.randomUUID()
 
-      whenever(repository.findAllByEntityUuidAndVersionBetween(uuid, 1767956400000L, 1767960000000L)).thenReturn(emptyList())
+      whenever(repository.findAllByEntityUuidAndVersionGreaterThanEqualAndVersionLessThan(uuid, 1767956400000L, 1767960000000L)).thenReturn(emptyList())
 
       val ex = assertThrows<Error> {
-        service.softDeleteVersions(uuid, from = 1767956400000L, to = 1767960000000L)
+        service.softDeleteVersions(uuid, from = 1767956400000L, to = 1767960000001L)
       }
 
       assertTrue(ex.message!!.contains("No versions found for entity $uuid between 1767956400000 to 1767960000000"))
-      verify(repository).findAllByEntityUuidAndVersionBetween(uuid, 1767956400000L, 1767960000000L)
+      verify(repository).findAllByEntityUuidAndVersionGreaterThanEqualAndVersionLessThan(uuid, 1767956400000L, 1767960000000L)
       verify(repository, never()).saveAll(anyList())
     }
 
@@ -162,12 +162,12 @@ class OasysVersionServiceTest {
       val uuid = UUID.randomUUID()
 
       val found = listOf(entity(uuid, 1767952800000), entity(uuid, 1767956400000L), entity(uuid, 1767960000000L))
-      whenever(repository.findAllByEntityUuidAndVersionBetween(uuid, 1767952800000, 1767960000000L)).thenReturn(found)
+      whenever(repository.findAllByEntityUuidAndVersionGreaterThanEqualAndVersionLessThan(uuid, 1767952800000, 1767960000000L)).thenReturn(found)
       whenever(repository.saveAll(anyList())).thenAnswer { it.arguments[0] as List<*> }
 
       val last = service.softDeleteVersions(uuid, from = 1767952800000, to = null)
 
-      verify(repository).findAllByEntityUuidAndVersionBetween(uuid, 1767952800000, 1767960000000L)
+      verify(repository).findAllByEntityUuidAndVersionGreaterThanEqualAndVersionLessThan(uuid, 1767952800000, 1767960000000L)
 
       verify(repository).saveAll(
         check<List<OasysVersionEntity>> {
@@ -183,13 +183,13 @@ class OasysVersionServiceTest {
     fun `it marks all returned entities deleted and returns the last version in the saveAll result`() {
       val uuid = UUID.randomUUID()
       val found = listOf(entity(uuid, 1767952800000), entity(uuid, 1767956400000L), entity(uuid, 1767960000000L))
-      whenever(repository.findAllByEntityUuidAndVersionBetween(uuid, 1767952800000, 1767960000000L)).thenReturn(found)
+      whenever(repository.findAllByEntityUuidAndVersionGreaterThanEqualAndVersionLessThan(uuid, 1767952800000, 1767960000000L)).thenReturn(found)
 
       val savedList =
         listOf(entity(uuid, 1767952800000, deleted = true), entity(uuid, 1767956400000L, deleted = true), entity(uuid, 1767960000000L, deleted = true))
       whenever(repository.saveAll(anyList())).thenReturn(savedList)
 
-      val last = service.softDeleteVersions(uuid, 1767952800000, 1767960000000L)
+      val last = service.softDeleteVersions(uuid, 1767952800000, 1767960000001L)
 
       assertEquals(1767960000000L, last.version)
       assertTrue(last.deleted)
@@ -205,7 +205,7 @@ class OasysVersionServiceTest {
       whenever(repository.findAllDeletedByEntityUuidAndVersionBetween(uuid, 1767952800000, 1767956400000L)).thenReturn(emptyList())
 
       assertThrows<Error> {
-        service.undeleteVersions(uuid, 1767952800000, 1767956400000L)
+        service.undeleteVersions(uuid, 1767952800000, 1767956400001L)
       }
 
       verify(repository).findAllDeletedByEntityUuidAndVersionBetween(uuid, 1767952800000, 1767956400000L)
@@ -243,7 +243,7 @@ class OasysVersionServiceTest {
       val savedList = listOf(entity(uuid, 1767952800000, deleted = false), entity(uuid, 1767956400000L, deleted = false))
       whenever(repository.saveAll(anyList())).thenReturn(savedList)
 
-      val last = service.undeleteVersions(uuid, 1767952800000, 1767956400000L)
+      val last = service.undeleteVersions(uuid, 1767952800000, 1767956400001L)
 
       assertEquals(1767956400000L, last.version)
       assertFalse(last.deleted)


### PR DESCRIPTION
- update repository queries to be `from` inclusive and `to` exclusive, this avoids an associations soft-deleting/undeleting versions from more recent associations and causing conflicts