### PR TITLE
SP2-2219: Add config to help with open search logs

### DIFF
--- a/helm_deploy/hmpps-assess-risks-and-needs-coordinator-api/values.yaml
+++ b/helm_deploy/hmpps-assess-risks-and-needs-coordinator-api/values.yaml
@@ -16,6 +16,9 @@ generic-service:
     modsecurity_enabled: true
     modsecurity_snippet: |
       SecRuleEngine DetectionOnly
+      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"


### PR DESCRIPTION
- Set SecDefaultAction with github_team=hmpps-assessments - Tags every ModSec log entry so we can find them in OpenSearch using "ModSecurity" and "github_team=hmpps-assessments"