### PR TITLE
Enable ModSecurity WAF across all environments

### DIFF
--- a/helm_deploy/hmpps-assess-risks-and-needs-coordinator-api/values.yaml
+++ b/helm_deploy/hmpps-assess-risks-and-needs-coordinator-api/values.yaml
@@ -14,8 +14,9 @@ generic-service:
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-assess-risks-and-needs-coordinator-api-cert
     modsecurity_enabled: true
+    modsecurity_audit_enabled: true
     modsecurity_snippet: |
-      SecRuleEngine DetectionOnly
+      SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking

--- a/helm_deploy/hmpps-assess-risks-and-needs-coordinator-api/values.yaml
+++ b/helm_deploy/hmpps-assess-risks-and-needs-coordinator-api/values.yaml
@@ -19,6 +19,8 @@ generic-service:
       SecRuleEngine DetectionOnly
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Block Detectify scanner with 418
+      SecRule REQUEST_HEADERS:User-Agent "@pm detectify Detectify DETECTIFY" "id:800003,phase:1,deny,status:418,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/hmpps-assess-risks-and-needs-coordinator-api/values.yaml
+++ b/helm_deploy/hmpps-assess-risks-and-needs-coordinator-api/values.yaml
@@ -16,7 +16,7 @@ generic-service:
     modsecurity_enabled: true
     modsecurity_audit_enabled: true
     modsecurity_snippet: |
-      SecRuleEngine On
+      SecRuleEngine DetectionOnly
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking


### PR DESCRIPTION
Enables ModSecurity WAF in **DetectionOnly** mode in **ALL** environments.

  We tested this in dev with SecRuleEngine On (blocking mode) and confirmed:                                                                                                                   
  - Malicious requests (XSS, scanner traffic) are correctly blocked with a 406 response
  - Legitimate traffic is unaffected
  - Detections are visible in [OpenSearch ](https://logs.cloud-platform.service.justice.gov.uk/_dashboards/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1h,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:b95d8900-dd15-11ed-87c8-170407f57c9c,key:github_teams,negate:!f,params:(query:hmpps-assessments),type:phrase),query:(match_phrase:(github_teams:hmpps-assessments)))),index:b95d8900-dd15-11ed-87c8-170407f57c9c,interval:auto,query:(language:kuery,query:''),sort:!()))under live_k8s_modsec_ingress-*, filterable by github_teams: hmpps-assessments

  We also ran in DetectionOnly mode on test to validate that real-world attack traffic (including active Detectify subdomain scans) is being detected and logged correctly before enabling     
  blocking.
