### PR TITLE
Enable ModSecurity WAF on dev and test environments

### DIFF
--- a/helm_deploy/hmpps-assess-risks-and-needs-coordinator-api/values.yaml
+++ b/helm_deploy/hmpps-assess-risks-and-needs-coordinator-api/values.yaml
@@ -13,15 +13,6 @@ generic-service:
     enabled: true
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-assess-risks-and-needs-coordinator-api-cert
-    modsecurity_enabled: true
-    modsecurity_snippet: |
-      SecRuleEngine DetectionOnly
-      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
-      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
-      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
-      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   # Environment variables to load into the deployment
   env:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,8 @@ generic-service:
       SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,6 +6,16 @@ generic-service:
 
   ingress:
     host: arns-coordinator-api-dev.hmpps.service.justice.gov.uk
+    modsecurity_enabled: true
+    modsecurity_audit_enabled: true
+    modsecurity_snippet: |
+      SecRuleEngine On
+      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -9,7 +9,7 @@ generic-service:
     modsecurity_enabled: true
     modsecurity_audit_enabled: true
     modsecurity_snippet: |
-      SecRuleEngine On
+      SecRuleEngine DetectionOnly
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -9,7 +9,7 @@ generic-service:
     modsecurity_enabled: true
     modsecurity_audit_enabled: true
     modsecurity_snippet: |
-      SecRuleEngine DetectionOnly
+      SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -12,6 +12,8 @@ generic-service:
       SecRuleEngine DetectionOnly
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -6,6 +6,16 @@ generic-service:
 
   ingress:
     host: arns-coordinator-api-test.hmpps.service.justice.gov.uk
+    modsecurity_enabled: true
+    modsecurity_audit_enabled: true
+    modsecurity_snippet: |
+      SecRuleEngine On
+      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -49,3 +49,4 @@ generic-service:
 generic-prometheus-alerts:
   alertSeverity: hmpps-assess-risks-and-needs-integrations-test
   businessHoursOnly: true
+  


### PR DESCRIPTION
Enable ModSecurity WAF on dev and test environments

Following a scanner traffic spike on 4 May that generated 403s at the nginx ingress, the Security team recommended enabling ModSecurity WAF. This PR introduces ModSec configuration per environment rather than globally, allowing us to safely validate behaviour before enabling full protection.