### PR TITLE
Remove ModSec WAF Config from Prod

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -6,18 +6,6 @@ generic-service:
 
   ingress:
     host: arns-coordinator-api.hmpps.service.justice.gov.uk
-    modsecurity_enabled: true
-    modsecurity_audit_enabled: true
-    modsecurity_snippet: |
-      SecRuleEngine DetectionOnly
-      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
-      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
-      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
-      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
-      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
-      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     HMPPS_AUTH_BASE_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"


### PR DESCRIPTION
Remove ModSec WAF Config from Prod environment until we can get to the bottom of why deploying this causes Sentence Plan to implode