### PR TITLE
Pin postgresql to 42.7.11 to fix CVE-2026-42198

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.wiremock:wiremock-standalone:3.13.2")
-  runtimeOnly("org.postgresql:postgresql")
+  runtimeOnly("org.postgresql:postgresql:42.7.11")
 
   // DB Migration (Flyway)
   implementation("org.springframework.boot:spring-boot-starter-flyway")


### PR DESCRIPTION
 The Spring Boot BOM resolves postgresql to 42.7.10, which is vulnerable to a client-side denial of service during SCRAM-SHA-256 authentication [(CVE-2026-42198)](https://nvd.nist.gov/vuln/detail/CVE-2026-42198). Pinned to 42.7.11 to override the BOM.