### PR TITLE
SP2-2507: Enable Modsec in Pre-Prod and Prod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -9,10 +9,7 @@ generic-service:
     className: modsec-non-prod
     modsecurity_enabled: true
     modsecurity_snippet: |
-      # Required for DetectionOnly: default audit logging is RelevantOnly (warnings/errors only);
-      # SecAuditEngine On gives full request visibility in OpenSearch while we monitor the rollout.
-      SecAuditEngine On
-      SecRuleEngine DetectionOnly
+      SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,10 +9,7 @@ generic-service:
     className: modsec
     modsecurity_enabled: true
     modsecurity_snippet: |
-      # Required for DetectionOnly: default audit logging is RelevantOnly (warnings/errors only);
-      # SecAuditEngine On gives full request visibility in OpenSearch while we monitor the rollout.
-      SecAuditEngine On
-      SecRuleEngine DetectionOnly
+      SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives


### PR DESCRIPTION
ModSec is already enabled in Dev/Test and in Detection Only for Pre-Prod/Prod, providing monitoring has gone well (i.e, we are not blocking any genuine requests to the AAP), this PR will now enable ModSec in the Coordinator