### PR TITLE
Add `additional_docker_tag` input to the multiplatform build workflow

### DIFF
--- a/.github/workflows/docker_build_multiplatform.yml
+++ b/.github/workflows/docker_build_multiplatform.yml
@@ -11,6 +11,10 @@ on:
         description: Tag image as latest
         type: boolean
         default: false
+      additional_docker_tag:
+        description: Additional tag to apply to the image (e.g. aap-san)
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -24,5 +28,6 @@ jobs:
       docker_registry: 'ghcr.io'
       registry_org: 'ministryofjustice'
       tag_latest: ${{ inputs.tag_latest }}
+      additional_docker_tag: ${{ inputs.additional_docker_tag }}
       push: ${{ inputs.push }}
       docker_multiplatform: true


### PR DESCRIPTION
The manual multiplatform build can't apply an extra tag, so moving a tag like `aap-san` onto a new build means hand-pushing from a laptop - which pushes a single-arch manifest and breaks amd64 CI runners downstream.

- Add an `additional_docker_tag` dispatch input (string, default empty)
- Pass it through to the shared `docker_build.yml`, which already accepts it

Now re-running the dispatch with e.g. `aap-san` writes the tag as a proper multi-arch index.